### PR TITLE
feat: Attribute workflow actions and assignments to owner

### DIFF
--- a/.github/workflows/auto-release.workflow.yml
+++ b/.github/workflows/auto-release.workflow.yml
@@ -67,9 +67,10 @@ jobs:
       - name: 🎫 Configure Git
         if: steps.check_commits.outputs.enough_commits == 'true'
         run: |
-          USER_NAME=$(curl -s -H "Authorization: token ${{ secrets.PAT_FINE }}" https://api.github.com/user | jq -r '.name')
+          USER_LOGIN=$(curl -s -H "Authorization: token ${{ secrets.PAT_FINE }}" https://api.github.com/user | jq -r '.login')
           USER_EMAIL=$(curl -s -H "Authorization: token ${{ secrets.PAT_FINE }}" https://api.github.com/user | jq -r '.email')
-          git config --global user.name "$USER_NAME"
+          echo "ACTOR_USERNAME=${USER_LOGIN}" >> $GITHUB_ENV
+          git config --global user.name "$USER_LOGIN"
           git config --global user.email "$USER_EMAIL"
       - name: 🟢 Setup Node.js
         if: steps.check_commits.outputs.enough_commits == 'true'
@@ -151,6 +152,11 @@ jobs:
           }'
           echo "Detected PR number: $PR_NUMBER"
           echo "prNumber=$PR_NUMBER" >> $GITHUB_OUTPUT
+      - name: 👤 Assign PR to user
+        if: steps.check_commits.outputs.enough_commits == 'true'
+        run: gh pr edit ${{ steps.create_pr.outputs.prNumber }} --add-assignee "${{ env.ACTOR_USERNAME }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FINE }}
       - name: 🕵️ Check if PR is approved
         if: steps.check_commits.outputs.enough_commits == 'true'
         uses: actions/github-script@v7

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -34,6 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
+      - name: Fetch actor username
+        id: get_actor_username
+        run: echo "ACTOR_USERNAME=$(gh api user -q .login)" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_FINE }}
       - name: 💿 Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2.4.0
@@ -43,19 +48,31 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
       - name: ✅ Approve patch and minor updates
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
         run: gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a patch or minor update**"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
+      - name: 👤 Assign PR to user (patch/minor)
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: gh pr edit $PR_URL --add-assignee "${{ env.ACTOR_USERNAME }}"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
       - name: ✅ Approve major updates of development dependencies
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:development'}}
         run: gh pr review $PR_URL --approve -b "I'm **approving** this pull request because **it includes a major update of a dependency used only in development**"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
+      - name: 👤 Assign PR to user (major dev)
+        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:development'}}
+        run: gh pr edit $PR_URL --add-assignee "${{ env.ACTOR_USERNAME }}"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PAT_FINE}}
       - name: 💬 Comment on major updates of non-development dependencies
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:production'}}
         run: |


### PR DESCRIPTION
This commit modifies the Dependabot auto-merge and Auto-release workflows:

Dependabot Auto-Merge (`dependabot-auto-merge.workflow.yml`):
- Approvals for Dependabot PRs are now performed using your PAT, attributing the approval action to you.
- Enabling auto-merge for Dependabot PRs is now also performed using your PAT, attributing this action to you.
- PRs are assigned to you, with the username fetched dynamically.
- Removed redundant GitHub CLI update step.

Auto-Release (`auto-release.workflow.yml`):
- Release PRs are now assigned to you.
- The username for assignment is fetched dynamically during the 'Configure Git' step, streamlining the workflow.

These changes ensure that relevant actions within these workflows are correctly attributed to you (via PAT) rather than the default `github-actions[bot]`, and PRs are appropriately assigned.