### PR TITLE
Add structured logging configuration across Fastypest

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "url": "https://github.com/juanjoGonDev/fastypest/issues"
   },
   "homepage": "https://github.com/juanjoGonDev/fastypest#readme",
+  "dependencies": {
+    "winston": "^3.14.2"
+  },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@swc-node/jest": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@swc/helpers": "^0.5.17",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.5.1",
+    "@types/winston": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.1",
     "@typescript-eslint/types": "8.44.1",

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,0 +1,71 @@
+const { addColors, createLogger, format, transports } = require("winston");
+
+const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+const LOG_COLORS = {
+  error: "red",
+  warn: "yellow",
+  info: "cyan",
+  debug: "magenta",
+};
+const LOG_TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
+const LOG_FIELD_LABEL = "label";
+const LOG_FIELD_METADATA = "metadata";
+const LOG_FIELD_MESSAGE = "message";
+const LOG_FIELD_LEVEL = "level";
+const LOG_FIELD_TIMESTAMP = "timestamp";
+const DEFAULT_SCOPE = "Script";
+const DEFAULT_LEVEL = "info";
+const DEFAULT_ENABLED = true;
+
+addColors(LOG_COLORS);
+
+const baseLogger = createLogger({
+  levels: LOG_LEVELS,
+  level: DEFAULT_LEVEL,
+  format: format.combine(
+    format.timestamp({ format: LOG_TIMESTAMP_FORMAT }),
+    format.metadata({
+      fillExcept: [LOG_FIELD_MESSAGE, LOG_FIELD_LEVEL, LOG_FIELD_TIMESTAMP, LOG_FIELD_LABEL],
+    }),
+    format.colorize({ all: true }),
+    format.printf((info) => formatMessage(info))
+  ),
+  transports: [new transports.Console()],
+  silent: false,
+});
+
+const formatMessage = (info) => {
+  const label = info[LOG_FIELD_LABEL] ?? DEFAULT_SCOPE;
+  const metadata = info[LOG_FIELD_METADATA];
+  const metadataText = metadata && Object.keys(metadata).length > 0 ? ` ${JSON.stringify(metadata)}` : "";
+  return `${info.timestamp} [${label}] ${info.level}: ${info.message}${metadataText}`;
+};
+
+const mergeOptions = (options = {}) => ({
+  enabled: options.enabled ?? DEFAULT_ENABLED,
+  level: options.level ?? DEFAULT_LEVEL,
+});
+
+const createScriptLogger = (scope = DEFAULT_SCOPE, options = {}) => {
+  const configuration = mergeOptions(options);
+  const log = (level, message, metadata) => {
+    if (!configuration.enabled) {
+      return;
+    }
+    baseLogger.level = configuration.level;
+    baseLogger.log({
+      level,
+      message,
+      [LOG_FIELD_LABEL]: scope,
+      [LOG_FIELD_METADATA]: metadata ?? {},
+    });
+  };
+  return {
+    error: (message, metadata) => log("error", message, metadata),
+    warn: (message, metadata) => log("warn", message, metadata),
+    info: (message, metadata) => log("info", message, metadata),
+    debug: (message, metadata) => log("debug", message, metadata),
+  };
+};
+
+module.exports = { createScriptLogger };

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,46 +1,101 @@
 const { addColors, createLogger, format, transports } = require("winston");
 
-const LOG_LEVELS = { error: 0, warn: 1, info: 2, debug: 3 };
+const LOG_LEVELS = {
+  error: 0,
+  warn: 1,
+  notice: 2,
+  info: 3,
+  debug: 4,
+  verbose: 5,
+};
+
 const LOG_COLORS = {
   error: "bold red",
   warn: "bold yellow",
-  info: "bold green",
-  debug: "bold cyan",
+  notice: "bold green",
+  info: "bold cyan",
+  debug: "bold magenta",
+  verbose: "bold blue",
 };
+
 const LOG_LEVEL_ICONS = {
   error: "❌",
   warn: "⚠️",
-  info: "ℹ️",
-  debug: "🔍",
+  notice: "🟢",
+  info: "💡",
+  debug: "🧭",
+  verbose: "🌀",
 };
+
 const LOG_LEVEL_LABELS = {
   error: "ERROR",
   warn: "WARN",
+  notice: "LOG",
   info: "INFO",
   debug: "DEBUG",
+  verbose: "VERBOSE",
 };
-const LOG_METADATA_SEPARATOR = " | ";
-const LOG_METADATA_KEY_VALUE_SEPARATOR = ": ";
+
 const LOG_TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
 const LOG_FIELD_LABEL = "label";
-const LOG_FIELD_METADATA = "metadata";
 const LOG_FIELD_MESSAGE = "message";
 const LOG_FIELD_LEVEL = "level";
 const LOG_FIELD_TIMESTAMP = "timestamp";
-const DEFAULT_SCOPE = "Script";
-const DEFAULT_LEVEL = "info";
+const LOG_FIELD_DETAILS = "details";
+const DETAIL_SEPARATOR = " · ";
+const DETAIL_PREFIX = " — ";
+const DEFAULT_LEVEL = "notice";
 const DEFAULT_ENABLED = true;
 
 addColors(LOG_COLORS);
 
+const formatDetailValue = (detail) => {
+  if (detail === undefined) {
+    return undefined;
+  }
+  if (detail === null) {
+    return "null";
+  }
+  if (detail instanceof Date) {
+    return detail.toISOString();
+  }
+  if (detail instanceof Error) {
+    return detail.message;
+  }
+  if (typeof detail === "boolean") {
+    return detail ? "yes" : "no";
+  }
+  return String(detail);
+};
+
+const formatDetails = (details = []) => {
+  const formatted = details
+    .map((detail) => formatDetailValue(detail))
+    .filter((value) => Boolean(value && value.length > 0));
+  if (formatted.length === 0) {
+    return undefined;
+  }
+  return formatted.join(DETAIL_SEPARATOR);
+};
+
+const formatMessage = (info) => {
+  const label = info[LOG_FIELD_LABEL];
+  const level = info[LOG_FIELD_LEVEL];
+  const timestamp = info[LOG_FIELD_TIMESTAMP];
+  const levelLabel = LOG_LEVEL_LABELS[level] ?? String(level ?? "");
+  const levelIcon = LOG_LEVEL_ICONS[level] ? `${LOG_LEVEL_ICONS[level]} ` : "";
+  const detailsText = info[LOG_FIELD_DETAILS]
+    ? `${DETAIL_PREFIX}${String(info[LOG_FIELD_DETAILS])}`
+    : "";
+  const timestampText = timestamp ? `${timestamp} ` : "";
+  return `${timestampText}${levelIcon}[${label ?? ""}] ${levelLabel} ${info[LOG_FIELD_MESSAGE]}${detailsText}`;
+};
+
 const baseLogger = createLogger({
   levels: LOG_LEVELS,
-  level: DEFAULT_LEVEL,
+  level: "verbose",
   format: format.combine(
     format.timestamp({ format: LOG_TIMESTAMP_FORMAT }),
-    format.metadata({
-      fillExcept: [LOG_FIELD_MESSAGE, LOG_FIELD_LEVEL, LOG_FIELD_TIMESTAMP, LOG_FIELD_LABEL],
-    }),
     format.colorize({ all: true }),
     format.printf((info) => formatMessage(info))
   ),
@@ -48,80 +103,43 @@ const baseLogger = createLogger({
   silent: false,
 });
 
-const formatValue = (value) => {
-  if (value === undefined) {
-    return "undefined";
-  }
-  if (value === null) {
-    return "null";
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => formatValue(entry)).join(", ");
-  }
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
-  return String(value);
-};
-
-const formatMetadata = (metadata) => {
-  if (!metadata) {
-    return "";
-  }
-  const entries = Object.entries(metadata);
-  if (entries.length === 0) {
-    return "";
-  }
-  return entries
-    .map(([key, value]) => `${key}${LOG_METADATA_KEY_VALUE_SEPARATOR}${formatValue(value)}`)
-    .join(LOG_METADATA_SEPARATOR);
-};
-
-const formatMessage = (info) => {
-  const label = info[LOG_FIELD_LABEL] ?? DEFAULT_SCOPE;
-  const metadata = info[LOG_FIELD_METADATA];
-  const level = info[LOG_FIELD_LEVEL];
-  const levelLabel = LOG_LEVEL_LABELS[level] ?? String(level ?? "");
-  const levelIcon = LOG_LEVEL_ICONS[level] ? `${LOG_LEVEL_ICONS[level]} ` : "";
-  const metadataText = formatMetadata(metadata);
-  const formattedMetadata = metadataText ? `${LOG_METADATA_SEPARATOR}${metadataText}` : "";
-  return `${info.timestamp} ${levelIcon}[${label}] ${levelLabel} ${info.message}${formattedMetadata}`;
-};
-
 const mergeOptions = (options = {}) => ({
   enabled: options.enabled ?? DEFAULT_ENABLED,
   level: options.level ?? DEFAULT_LEVEL,
 });
 
-const createScriptLogger = (scope = DEFAULT_SCOPE, options = {}) => {
+const normalizeDetails = (details) => {
+  if (!details) {
+    return [];
+  }
+  return details.flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
+};
+
+const createScriptLogger = (scope, options = {}) => {
   const configuration = mergeOptions(options);
-  const log = (level, message, metadata) => {
+  const log = (level, message, details = []) => {
     if (!configuration.enabled) {
       return;
     }
     baseLogger.level = configuration.level;
-    const metadataEntries = metadata ? Object.entries(metadata) : [];
+    const detailText = formatDetails(normalizeDetails(details));
     const payload = {
       level,
       message,
       [LOG_FIELD_LABEL]: scope,
     };
-    if (metadataEntries.length > 0) {
-      payload[LOG_FIELD_METADATA] = metadataEntries.reduce((accumulator, [key, value]) => {
-        accumulator[key] = value;
-        return accumulator;
-      }, {});
+    if (detailText) {
+      payload[LOG_FIELD_DETAILS] = detailText;
     }
     baseLogger.log(payload);
   };
   return {
-    error: (message, metadata) => log("error", message, metadata),
-    warn: (message, metadata) => log("warn", message, metadata),
-    info: (message, metadata) => log("info", message, metadata),
-    debug: (message, metadata) => log("debug", message, metadata),
+    error: (message, ...details) => log("error", message, details),
+    warn: (message, ...details) => log("warn", message, details),
+    log: (message, ...details) => log("notice", message, details),
+    info: (message, ...details) => log("info", message, details),
+    debug: (message, ...details) => log("debug", message, details),
+    verbose: (message, ...details) => log("verbose", message, details),
   };
 };
 

--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -3,17 +3,21 @@ const path = require("path");
 const { createScriptLogger } = require("./logger");
 
 const LOG_SCOPE = "pre-commit";
-const LOG_MESSAGE_COMMAND_ERROR = "Error executing command";
-const LOG_MESSAGE_REMOVED_DIRECTORY = "Removed test-install directory";
-const LOG_MESSAGE_BUILDING_PACKAGE = "Building the package";
-const LOG_MESSAGE_PACKING_PACKAGE = "Packing the package";
-const LOG_MESSAGE_INITIALIZING_PROJECT = "Initializing test-install project";
-const LOG_MESSAGE_ADDING_TARBALL = "Adding tarball as dev dependency";
-const LOG_MESSAGE_SUCCESS = "Pre-commit install test succeeded";
-const LOG_MESSAGE_FAILURE = "Pre-commit check failed";
-const METADATA_KEY_COMMAND = "command";
-const METADATA_KEY_ARGUMENTS = "args";
-const METADATA_KEY_ERROR = "error";
+const LOG_TEXT = Object.freeze({
+  commandError: "💥 Error executing command",
+  removedDirectory: "🧹 Removed test-install directory",
+  buildingPackage: "🏗️ Building the package",
+  packingPackage: "📦 Packing the package",
+  initializingProject: "🆕 Initializing test-install project",
+  addingTarball: "➕ Adding tarball as dev dependency",
+  success: "✅ Pre-commit install test succeeded",
+  failure: "❌ Pre-commit check failed",
+});
+const METADATA_KEYS = Object.freeze({
+  command: "command",
+  arguments: "args",
+  error: "error",
+});
 
 const logger = createScriptLogger(LOG_SCOPE);
 
@@ -23,10 +27,10 @@ const run = async (command, args = [], options = { stdio: "inherit" }) => {
     const { stdout } = await execa(command, args, options);
     return stdout;
   } catch (err) {
-    logger.error(LOG_MESSAGE_COMMAND_ERROR, {
-      [METADATA_KEY_COMMAND]: command,
-      [METADATA_KEY_ARGUMENTS]: args,
-      [METADATA_KEY_ERROR]: err.stderr || err.message || err,
+    logger.error(LOG_TEXT.commandError, {
+      [METADATA_KEYS.command]: command,
+      [METADATA_KEYS.arguments]: args,
+      [METADATA_KEYS.error]: err.stderr || err.message || err,
     });
     throw err;
   }
@@ -38,23 +42,23 @@ const packagePath = path.join(testInstallDir, "package.tar.gz");
 const cleanUp = () => {
   if (fs.existsSync(testInstallDir)) {
     fs.rmSync(testInstallDir, { recursive: true, force: true });
-    logger.info(LOG_MESSAGE_REMOVED_DIRECTORY);
+    logger.info(LOG_TEXT.removedDirectory);
   }
 };
 
 (async () => {
   try {
-    logger.info(LOG_MESSAGE_BUILDING_PACKAGE);
+    logger.info(LOG_TEXT.buildingPackage);
     await run("yarn", ["build"]);
 
     if (!fs.existsSync(testInstallDir)) {
       fs.mkdirSync(testInstallDir);
     }
 
-    logger.info(LOG_MESSAGE_PACKING_PACKAGE);
+    logger.info(LOG_TEXT.packingPackage);
     await run("yarn", ["pack", "--filename", packagePath]);
 
-    logger.info(LOG_MESSAGE_INITIALIZING_PROJECT);
+    logger.info(LOG_TEXT.initializingProject);
     await run("yarn", ["init", "-y"], { cwd: testInstallDir });
 
     const yarnLockPath = path.join(testInstallDir, "yarn.lock");
@@ -62,17 +66,17 @@ const cleanUp = () => {
       fs.writeFileSync(yarnLockPath, "");
     }
 
-    logger.info(LOG_MESSAGE_ADDING_TARBALL);
+    logger.info(LOG_TEXT.addingTarball);
     await run(
       "yarn",
       ["add", "-D", `fastypest@${packagePath}`],
       { cwd: testInstallDir }
     );
 
-    logger.info(LOG_MESSAGE_SUCCESS);
+    logger.info(LOG_TEXT.success);
   } catch (error) {
-    logger.error(LOG_MESSAGE_FAILURE, {
-      [METADATA_KEY_ERROR]: error.message || error,
+    logger.error(LOG_TEXT.failure, {
+      [METADATA_KEYS.error]: error.message || error,
     });
     process.exitCode = 1;
   } finally {

--- a/src/core/fastypest.ts
+++ b/src/core/fastypest.ts
@@ -23,46 +23,50 @@ import { configureLogging, createScopedLogger } from "../logging";
 import type { LoggingOptions, ScopedLogger } from "../logging";
 
 const LOG_SCOPE_FASTYPEST = "Fastypest";
-const LOG_MESSAGE_LOGGING_ENABLED = "Logging enabled";
-const LOG_MESSAGE_LOGGING_DISABLED = "Logging disabled";
-const LOG_MESSAGE_CHANGE_TRACKING_ENABLED = "Change detection strategy enabled";
-const LOG_MESSAGE_SUBSCRIBER_REGISTERED = "Change tracking subscriber registered";
-const LOG_MESSAGE_INITIALIZATION_STARTED = "Initialization started";
-const LOG_MESSAGE_INITIALIZATION_COMPLETED = "Initialization completed";
-const LOG_MESSAGE_TABLES_DISCOVERED = "Tables discovered";
-const LOG_MESSAGE_DEPENDENCIES_READY = "Dependency order calculated";
-const LOG_MESSAGE_TEMP_TABLES_PREPARED = "Temporary tables prepared";
-const LOG_MESSAGE_AUTO_INCREMENT_ANALYZED = "Auto increment analysis completed";
-const LOG_MESSAGE_AUTO_INCREMENT_COLUMN = "Auto increment column processed";
-const LOG_MESSAGE_RESTORE_STARTED = "Restore process started";
-const LOG_MESSAGE_RESTORE_MODE = "Restore mode selected";
-const LOG_MESSAGE_RESTORING_TABLE = "Restoring table";
-const LOG_MESSAGE_TABLE_RESTORED = "Table restored";
-const LOG_MESSAGE_TABLE_TRUNCATED = "Table truncated";
-const LOG_MESSAGE_DATA_RESTORED = "Table data restored";
-const LOG_MESSAGE_FOREIGN_KEY_DISABLED = "Foreign keys disabled";
-const LOG_MESSAGE_FOREIGN_KEY_ENABLED = "Foreign keys enabled";
-const LOG_MESSAGE_RESTORE_COMPLETED = "Restore process completed";
-const LOG_MESSAGE_AUTO_INCREMENT_RESET = "Auto increment column reset";
-const LOG_MESSAGE_CHANGE_DETECTED = "Table change detected";
-const LOG_MESSAGE_NO_CHANGES = "No tracked changes detected";
-const LOG_MESSAGE_FILTERED_TABLES = "Filtered tables by detected changes";
+const LOG_TEXT = {
+  loggingEnabled: "🟢 Logging enabled",
+  loggingDisabled: "⚪️ Logging disabled",
+  changeTrackingEnabled: "🛰️ Change detection strategy enabled",
+  subscriberRegistered: "📡 Change tracking subscriber registered",
+  initializationStarted: "🚀 Initialization started",
+  initializationCompleted: "✅ Initialization completed",
+  tablesDiscovered: "🗂️ Tables discovered",
+  dependenciesReady: "🧭 Dependency order calculated",
+  tempTablesPrepared: "🧪 Temporary tables prepared",
+  autoIncrementAnalyzed: "📊 Auto increment analysis completed",
+  autoIncrementColumn: "🔁 Auto increment column processed",
+  restoreStarted: "🛠️ Restore process started",
+  restoreMode: "🧱 Restore mode selected",
+  restoringTable: "📥 Restoring table",
+  tableRestored: "✅ Table restored",
+  tableTruncated: "🧹 Table truncated",
+  dataRestored: "📦 Table data restored",
+  foreignKeyDisabled: "🚧 Foreign keys disabled",
+  foreignKeyEnabled: "🆗 Foreign keys enabled",
+  restoreCompleted: "🎉 Restore process completed",
+  autoIncrementReset: "♻️ Auto increment column reset",
+  changeDetected: "🔎 Table change detected",
+  noChanges: "🕊️ No tracked changes detected",
+  filteredTables: "🗜️ Filtered tables by detected changes",
+} as const;
 
-const METADATA_KEY_DATABASE_TYPE = "databaseType";
-const METADATA_KEY_LOGGING_ENABLED = "loggingEnabled";
-const METADATA_KEY_LOGGING_LEVEL = "loggingLevel";
-const METADATA_KEY_CHANGE_STRATEGY = "changeDetectionStrategy";
-const METADATA_KEY_DURATION_SECONDS = "durationInSeconds";
-const METADATA_KEY_TOTAL_TABLES = "totalTables";
-const METADATA_KEY_TABLE = "table";
-const METADATA_KEY_PROGRESS_CURRENT = "current";
-const METADATA_KEY_PROGRESS_TOTAL = "total";
-const METADATA_KEY_MODE = "mode";
-const METADATA_KEY_SEQUENCES = "sequences";
-const METADATA_KEY_COLUMNS = "columns";
-const METADATA_KEY_TABLES_WITH_AUTO_INCREMENT = "tablesWithAutoIncrement";
-const METADATA_KEY_CHANGED_TABLES = "changedTables";
-const METADATA_KEY_TABLES_RESTORED = "tablesRestored";
+const METADATA_KEYS = {
+  databaseType: "databaseType",
+  loggingEnabled: "loggingEnabled",
+  loggingLevel: "loggingLevel",
+  changeDetectionStrategy: "changeDetectionStrategy",
+  durationSeconds: "durationInSeconds",
+  totalTables: "totalTables",
+  table: "table",
+  progressCurrent: "current",
+  progressTotal: "total",
+  mode: "mode",
+  sequences: "sequences",
+  columns: "columns",
+  tablesWithAutoIncrement: "tablesWithAutoIncrement",
+  changedTables: "changedTables",
+  tablesRestored: "tablesRestored",
+} as const;
 
 const RESTORE_MODE_ORDERED = "ordered";
 const RESTORE_MODE_PARALLEL = "parallel";
@@ -94,29 +98,27 @@ export class Fastypest extends SQLScript {
         options?.changeDetectionStrategy ?? ChangeDetectionStrategy.None,
     };
     this.logger.info(
-      resolvedLogging.enabled
-        ? LOG_MESSAGE_LOGGING_ENABLED
-        : LOG_MESSAGE_LOGGING_DISABLED,
+      resolvedLogging.enabled ? LOG_TEXT.loggingEnabled : LOG_TEXT.loggingDisabled,
       {
-        [METADATA_KEY_LOGGING_ENABLED]: resolvedLogging.enabled,
-        [METADATA_KEY_LOGGING_LEVEL]: resolvedLogging.level,
-        [METADATA_KEY_DATABASE_TYPE]: this.getType(),
-        [METADATA_KEY_CHANGE_STRATEGY]: this.options.changeDetectionStrategy,
+        [METADATA_KEYS.loggingEnabled]: resolvedLogging.enabled,
+        [METADATA_KEYS.loggingLevel]: resolvedLogging.level,
+        [METADATA_KEYS.databaseType]: this.getType(),
+        [METADATA_KEYS.changeDetectionStrategy]: this.options.changeDetectionStrategy,
       }
     );
     if (
       this.options.changeDetectionStrategy ===
       ChangeDetectionStrategy.Subscriber
     ) {
-      this.logger.info(LOG_MESSAGE_CHANGE_TRACKING_ENABLED);
+      this.logger.info(LOG_TEXT.changeTrackingEnabled);
       this.registerSubscriber(connection);
     }
   }
 
   public async init(): Promise<void> {
     const startTime = performance.now();
-    this.logger.info(LOG_MESSAGE_INITIALIZATION_STARTED, {
-      [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+    this.logger.info(LOG_TEXT.initializationStarted, {
+      [METADATA_KEYS.databaseType]: this.getType(),
     });
     await this.manager.transaction(async (em: EntityManager) => {
       await this.detectTables(em);
@@ -127,12 +129,12 @@ export class Fastypest extends SQLScript {
         this.detectTablesWithAutoIncrement(em, tables),
       ]);
     });
-    this.logger.info(LOG_MESSAGE_INITIALIZATION_COMPLETED, {
-      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+    this.logger.info(LOG_TEXT.initializationCompleted, {
+      [METADATA_KEYS.durationSeconds]: this.formatDuration(
         performance.now() - startTime
       ),
-      [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
-      [METADATA_KEY_TABLES_WITH_AUTO_INCREMENT]:
+      [METADATA_KEYS.totalTables]: this.tables.size,
+      [METADATA_KEYS.tablesWithAutoIncrement]:
         this.tablesWithAutoIncrement.size,
     });
   }
@@ -146,10 +148,10 @@ export class Fastypest extends SQLScript {
       tables.map(async (tableName, index) => {
         await this.execQuery(em, "dropTempTable", { tableName });
         await this.execQuery(em, "createTempTable", { tableName });
-        this.logger.debug(LOG_MESSAGE_TEMP_TABLES_PREPARED, {
-          [METADATA_KEY_TABLE]: tableName,
-          [METADATA_KEY_PROGRESS_CURRENT]: index + PROGRESS_OFFSET,
-          [METADATA_KEY_PROGRESS_TOTAL]: totalTables,
+        this.logger.debug(LOG_TEXT.tempTablesPrepared, {
+          [METADATA_KEYS.table]: tableName,
+          [METADATA_KEYS.progressCurrent]: index + PROGRESS_OFFSET,
+          [METADATA_KEYS.progressTotal]: totalTables,
         });
       })
     );
@@ -163,8 +165,8 @@ export class Fastypest extends SQLScript {
     for (const [index, tableName] of tables.entries()) {
       await this.processTable(em, tableName, index + PROGRESS_OFFSET, totalTables);
     }
-    this.logger.debug(LOG_MESSAGE_AUTO_INCREMENT_ANALYZED, {
-      [METADATA_KEY_TABLES_WITH_AUTO_INCREMENT]: this.tablesWithAutoIncrement.size,
+    this.logger.debug(LOG_TEXT.autoIncrementAnalyzed, {
+      [METADATA_KEYS.tablesWithAutoIncrement]: this.tablesWithAutoIncrement.size,
     });
   }
 
@@ -215,12 +217,12 @@ export class Fastypest extends SQLScript {
       sequenceName,
       index: String(index + (INDEX_OFFSET_CONFIG[this.getType()] ?? 0)),
     });
-    this.logger.debug(LOG_MESSAGE_AUTO_INCREMENT_COLUMN, {
-      [METADATA_KEY_TABLE]: tableName,
-      [METADATA_KEY_COLUMNS]: column.column_name,
-      [METADATA_KEY_SEQUENCES]: sequenceName,
-      [METADATA_KEY_PROGRESS_CURRENT]: position,
-      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    this.logger.debug(LOG_TEXT.autoIncrementColumn, {
+      [METADATA_KEYS.table]: tableName,
+      [METADATA_KEYS.columns]: column.column_name,
+      [METADATA_KEYS.sequences]: sequenceName,
+      [METADATA_KEYS.progressCurrent]: position,
+      [METADATA_KEYS.progressTotal]: total,
     });
   }
 
@@ -255,13 +257,13 @@ export class Fastypest extends SQLScript {
     const startTime = performance.now();
     const tablesToRestore = this.getTablesForRestore();
     if (this.shouldTrackChanges() && this.changedTables.size === 0) {
-      this.logger.debug(LOG_MESSAGE_NO_CHANGES, {
-        [METADATA_KEY_TOTAL_TABLES]: tablesToRestore.length,
+      this.logger.debug(LOG_TEXT.noChanges, {
+        [METADATA_KEYS.totalTables]: tablesToRestore.length,
       });
     }
-    this.logger.info(LOG_MESSAGE_RESTORE_STARTED, {
-      [METADATA_KEY_TOTAL_TABLES]: tablesToRestore.length,
-      [METADATA_KEY_CHANGED_TABLES]: this.shouldTrackChanges()
+    this.logger.info(LOG_TEXT.restoreStarted, {
+      [METADATA_KEYS.totalTables]: tablesToRestore.length,
+      [METADATA_KEYS.changedTables]: this.shouldTrackChanges()
         ? this.changedTables.size
         : undefined,
     });
@@ -271,11 +273,11 @@ export class Fastypest extends SQLScript {
       await restoreOrder();
       await foreignKey.enable();
     });
-    this.logger.info(LOG_MESSAGE_RESTORE_COMPLETED, {
-      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+    this.logger.info(LOG_TEXT.restoreCompleted, {
+      [METADATA_KEYS.durationSeconds]: this.formatDuration(
         performance.now() - startTime
       ),
-      [METADATA_KEY_TABLES_RESTORED]: tablesToRestore.length,
+      [METADATA_KEYS.tablesRestored]: tablesToRestore.length,
     });
   }
 
@@ -295,15 +297,15 @@ export class Fastypest extends SQLScript {
     const typesWithForeignKey: DBType[] = ["postgres", "mariadb", "mysql"];
     if (typesWithForeignKey.includes(this.getType())) {
       manager.foreignKey.disable = async (): Promise<void> => {
-        this.logger.debug(LOG_MESSAGE_FOREIGN_KEY_DISABLED, {
-          [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+        this.logger.debug(LOG_TEXT.foreignKeyDisabled, {
+          [METADATA_KEYS.databaseType]: this.getType(),
         });
         await this.execQuery(em, "foreignKey.disable");
       };
       manager.foreignKey.enable = async (): Promise<void> => {
         await this.execQuery(em, "foreignKey.enable");
-        this.logger.debug(LOG_MESSAGE_FOREIGN_KEY_ENABLED, {
-          [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+        this.logger.debug(LOG_TEXT.foreignKeyEnabled, {
+          [METADATA_KEYS.databaseType]: this.getType(),
         });
       };
     }
@@ -322,12 +324,12 @@ export class Fastypest extends SQLScript {
 
     if (!dependencyTree.length) {
       this.restoreInOder = false;
-      this.logger.debug(LOG_MESSAGE_DEPENDENCIES_READY, {
-        [METADATA_KEY_MODE]: RESTORE_MODE_PARALLEL,
-        [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+      this.logger.debug(LOG_TEXT.dependenciesReady, {
+        [METADATA_KEYS.mode]: RESTORE_MODE_PARALLEL,
+        [METADATA_KEYS.durationSeconds]: this.formatDuration(
           performance.now() - startTime
         ),
-        [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+        [METADATA_KEYS.totalTables]: this.tables.size,
       });
       return;
     }
@@ -336,12 +338,12 @@ export class Fastypest extends SQLScript {
     this.tables.clear();
     this.tables = sortedTables;
     this.restoreInOder = true;
-    this.logger.debug(LOG_MESSAGE_DEPENDENCIES_READY, {
-      [METADATA_KEY_MODE]: RESTORE_MODE_ORDERED,
-      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+    this.logger.debug(LOG_TEXT.dependenciesReady, {
+      [METADATA_KEYS.mode]: RESTORE_MODE_ORDERED,
+      [METADATA_KEYS.durationSeconds]: this.formatDuration(
         performance.now() - startTime
       ),
-      [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+      [METADATA_KEYS.totalTables]: this.tables.size,
     });
   }
 
@@ -349,9 +351,9 @@ export class Fastypest extends SQLScript {
     const startTime = performance.now();
     const tables = await this.execQuery<Table>(em, "getTables");
     if (!tables) {
-      this.logger.debug(LOG_MESSAGE_TABLES_DISCOVERED, {
-        [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
-        [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+      this.logger.debug(LOG_TEXT.tablesDiscovered, {
+        [METADATA_KEYS.totalTables]: this.tables.size,
+        [METADATA_KEYS.durationSeconds]: this.formatDuration(
           performance.now() - startTime
         ),
       });
@@ -361,9 +363,9 @@ export class Fastypest extends SQLScript {
     tables.forEach((row) => {
       this.tables.add(row.name);
     });
-    this.logger.debug(LOG_MESSAGE_TABLES_DISCOVERED, {
-      [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
-      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+    this.logger.debug(LOG_TEXT.tablesDiscovered, {
+      [METADATA_KEYS.totalTables]: this.tables.size,
+      [METADATA_KEYS.durationSeconds]: this.formatDuration(
         performance.now() - startTime
       ),
     });
@@ -373,9 +375,9 @@ export class Fastypest extends SQLScript {
     const tables = this.getTablesForRestore();
     const totalTables = tables.length;
     if (this.restoreInOder) {
-      this.logger.debug(LOG_MESSAGE_RESTORE_MODE, {
-        [METADATA_KEY_MODE]: RESTORE_MODE_ORDERED,
-        [METADATA_KEY_TOTAL_TABLES]: totalTables,
+      this.logger.debug(LOG_TEXT.restoreMode, {
+        [METADATA_KEYS.mode]: RESTORE_MODE_ORDERED,
+        [METADATA_KEYS.totalTables]: totalTables,
       });
       for (const [index, tableName] of tables.entries()) {
         await this.recreateData(
@@ -386,9 +388,9 @@ export class Fastypest extends SQLScript {
         );
       }
     } else {
-      this.logger.debug(LOG_MESSAGE_RESTORE_MODE, {
-        [METADATA_KEY_MODE]: RESTORE_MODE_PARALLEL,
-        [METADATA_KEY_TOTAL_TABLES]: totalTables,
+      this.logger.debug(LOG_TEXT.restoreMode, {
+        [METADATA_KEYS.mode]: RESTORE_MODE_PARALLEL,
+        [METADATA_KEYS.totalTables]: totalTables,
       });
       await Promise.all(
         tables.map((tableName, index) =>
@@ -413,31 +415,31 @@ export class Fastypest extends SQLScript {
     total: number
   ): Promise<void> {
     const startTime = performance.now();
-    this.logger.info(LOG_MESSAGE_RESTORING_TABLE, {
-      [METADATA_KEY_TABLE]: tableName,
-      [METADATA_KEY_PROGRESS_CURRENT]: position,
-      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    this.logger.info(LOG_TEXT.restoringTable, {
+      [METADATA_KEYS.table]: tableName,
+      [METADATA_KEYS.progressCurrent]: position,
+      [METADATA_KEYS.progressTotal]: total,
     });
     await this.execQuery(em, "truncateTable", { tableName });
-    this.logger.debug(LOG_MESSAGE_TABLE_TRUNCATED, {
-      [METADATA_KEY_TABLE]: tableName,
-      [METADATA_KEY_PROGRESS_CURRENT]: position,
-      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    this.logger.debug(LOG_TEXT.tableTruncated, {
+      [METADATA_KEYS.table]: tableName,
+      [METADATA_KEYS.progressCurrent]: position,
+      [METADATA_KEYS.progressTotal]: total,
     });
     await this.execQuery(em, "restoreData", { tableName });
-    this.logger.debug(LOG_MESSAGE_DATA_RESTORED, {
-      [METADATA_KEY_TABLE]: tableName,
-      [METADATA_KEY_PROGRESS_CURRENT]: position,
-      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    this.logger.debug(LOG_TEXT.dataRestored, {
+      [METADATA_KEYS.table]: tableName,
+      [METADATA_KEYS.progressCurrent]: position,
+      [METADATA_KEYS.progressTotal]: total,
     });
     await this.resetAutoIncrementColumns(em, tableName);
-    this.logger.info(LOG_MESSAGE_TABLE_RESTORED, {
-      [METADATA_KEY_TABLE]: tableName,
-      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+    this.logger.info(LOG_TEXT.tableRestored, {
+      [METADATA_KEYS.table]: tableName,
+      [METADATA_KEYS.durationSeconds]: this.formatDuration(
         performance.now() - startTime
       ),
-      [METADATA_KEY_PROGRESS_CURRENT]: position,
-      [METADATA_KEY_PROGRESS_TOTAL]: total,
+      [METADATA_KEYS.progressCurrent]: position,
+      [METADATA_KEYS.progressTotal]: total,
     });
   }
 
@@ -455,10 +457,10 @@ export class Fastypest extends SQLScript {
         sequenceName,
         index,
       });
-      this.logger.debug(LOG_MESSAGE_AUTO_INCREMENT_RESET, {
-        [METADATA_KEY_TABLE]: tableName,
-        [METADATA_KEY_COLUMNS]: column,
-        [METADATA_KEY_SEQUENCES]: sequenceName,
+      this.logger.debug(LOG_TEXT.autoIncrementReset, {
+        [METADATA_KEYS.table]: tableName,
+        [METADATA_KEYS.columns]: column,
+        [METADATA_KEYS.sequences]: sequenceName,
         index,
       });
     }
@@ -470,8 +472,8 @@ export class Fastypest extends SQLScript {
     });
     this.getSubscriberCollection(connection).push(subscriber);
     this.bindSubscriber(subscriber, connection);
-    this.logger.info(LOG_MESSAGE_SUBSCRIBER_REGISTERED, {
-      [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+    this.logger.info(LOG_TEXT.subscriberRegistered, {
+      [METADATA_KEYS.databaseType]: this.getType(),
     });
   }
 
@@ -521,9 +523,9 @@ export class Fastypest extends SQLScript {
     if (filtered.length === 0) {
       return tables;
     }
-    this.logger.debug(LOG_MESSAGE_FILTERED_TABLES, {
-      [METADATA_KEY_CHANGED_TABLES]: filtered.length,
-      [METADATA_KEY_TOTAL_TABLES]: tables.length,
+    this.logger.debug(LOG_TEXT.filteredTables, {
+      [METADATA_KEYS.changedTables]: filtered.length,
+      [METADATA_KEYS.totalTables]: tables.length,
     });
     return filtered;
   }
@@ -535,9 +537,9 @@ export class Fastypest extends SQLScript {
     const wasTracked = this.changedTables.has(tableName);
     this.changedTables.add(tableName);
     if (!wasTracked) {
-      this.logger.debug(LOG_MESSAGE_CHANGE_DETECTED, {
-        [METADATA_KEY_TABLE]: tableName,
-        [METADATA_KEY_CHANGED_TABLES]: this.changedTables.size,
+      this.logger.debug(LOG_TEXT.changeDetected, {
+        [METADATA_KEYS.table]: tableName,
+        [METADATA_KEYS.changedTables]: this.changedTables.size,
       });
     }
   }

--- a/src/core/fastypest.ts
+++ b/src/core/fastypest.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import {
   Connection,
   DataSource,
@@ -18,34 +19,105 @@ import {
   type IncrementDetail,
   type Manager,
 } from "./types";
+import { configureLogging, createScopedLogger } from "../logging";
+import type { LoggingOptions, ScopedLogger } from "../logging";
+
+const LOG_SCOPE_FASTYPEST = "Fastypest";
+const LOG_MESSAGE_LOGGING_ENABLED = "Logging enabled";
+const LOG_MESSAGE_LOGGING_DISABLED = "Logging disabled";
+const LOG_MESSAGE_CHANGE_TRACKING_ENABLED = "Change detection strategy enabled";
+const LOG_MESSAGE_SUBSCRIBER_REGISTERED = "Change tracking subscriber registered";
+const LOG_MESSAGE_INITIALIZATION_STARTED = "Initialization started";
+const LOG_MESSAGE_INITIALIZATION_COMPLETED = "Initialization completed";
+const LOG_MESSAGE_TABLES_DISCOVERED = "Tables discovered";
+const LOG_MESSAGE_DEPENDENCIES_READY = "Dependency order calculated";
+const LOG_MESSAGE_TEMP_TABLES_PREPARED = "Temporary tables prepared";
+const LOG_MESSAGE_AUTO_INCREMENT_ANALYZED = "Auto increment analysis completed";
+const LOG_MESSAGE_AUTO_INCREMENT_COLUMN = "Auto increment column processed";
+const LOG_MESSAGE_RESTORE_STARTED = "Restore process started";
+const LOG_MESSAGE_RESTORE_MODE = "Restore mode selected";
+const LOG_MESSAGE_RESTORING_TABLE = "Restoring table";
+const LOG_MESSAGE_TABLE_RESTORED = "Table restored";
+const LOG_MESSAGE_TABLE_TRUNCATED = "Table truncated";
+const LOG_MESSAGE_DATA_RESTORED = "Table data restored";
+const LOG_MESSAGE_FOREIGN_KEY_DISABLED = "Foreign keys disabled";
+const LOG_MESSAGE_FOREIGN_KEY_ENABLED = "Foreign keys enabled";
+const LOG_MESSAGE_RESTORE_COMPLETED = "Restore process completed";
+const LOG_MESSAGE_AUTO_INCREMENT_RESET = "Auto increment column reset";
+const LOG_MESSAGE_CHANGE_DETECTED = "Table change detected";
+const LOG_MESSAGE_NO_CHANGES = "No tracked changes detected";
+const LOG_MESSAGE_FILTERED_TABLES = "Filtered tables by detected changes";
+
+const METADATA_KEY_DATABASE_TYPE = "databaseType";
+const METADATA_KEY_LOGGING_ENABLED = "loggingEnabled";
+const METADATA_KEY_LOGGING_LEVEL = "loggingLevel";
+const METADATA_KEY_CHANGE_STRATEGY = "changeDetectionStrategy";
+const METADATA_KEY_DURATION_SECONDS = "durationInSeconds";
+const METADATA_KEY_TOTAL_TABLES = "totalTables";
+const METADATA_KEY_TABLE = "table";
+const METADATA_KEY_PROGRESS_CURRENT = "current";
+const METADATA_KEY_PROGRESS_TOTAL = "total";
+const METADATA_KEY_MODE = "mode";
+const METADATA_KEY_SEQUENCES = "sequences";
+const METADATA_KEY_COLUMNS = "columns";
+const METADATA_KEY_TABLES_WITH_AUTO_INCREMENT = "tablesWithAutoIncrement";
+const METADATA_KEY_CHANGED_TABLES = "changedTables";
+const METADATA_KEY_TABLES_RESTORED = "tablesRestored";
+
+const RESTORE_MODE_ORDERED = "ordered";
+const RESTORE_MODE_PARALLEL = "parallel";
+
+const MILLISECONDS_IN_SECOND = 1000;
+const DURATION_PRECISION = 2;
+const PROGRESS_OFFSET = 1;
 
 export class Fastypest extends SQLScript {
   private manager: EntityManager;
   private tables: Set<string> = new Set();
   private tablesWithAutoIncrement: Map<string, IncrementDetail[]> = new Map();
   private restoreInOder: boolean = false;
-  private readonly options: Required<FastypestOptions>;
+  private readonly options: Required<Omit<FastypestOptions, "logging">>;
   private readonly changedTables: Set<string> = new Set();
+  private readonly logger: ScopedLogger;
 
   constructor(
     connection: DataSource | Connection,
     options?: FastypestOptions
   ) {
     super(connection.options.type);
+    const loggingConfiguration = this.resolveLoggingConfiguration(options?.logging);
+    const resolvedLogging = configureLogging(loggingConfiguration);
+    this.logger = createScopedLogger(LOG_SCOPE_FASTYPEST);
     this.manager = connection.manager;
     this.options = {
       changeDetectionStrategy:
         options?.changeDetectionStrategy ?? ChangeDetectionStrategy.None,
     };
+    this.logger.info(
+      resolvedLogging.enabled
+        ? LOG_MESSAGE_LOGGING_ENABLED
+        : LOG_MESSAGE_LOGGING_DISABLED,
+      {
+        [METADATA_KEY_LOGGING_ENABLED]: resolvedLogging.enabled,
+        [METADATA_KEY_LOGGING_LEVEL]: resolvedLogging.level,
+        [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+        [METADATA_KEY_CHANGE_STRATEGY]: this.options.changeDetectionStrategy,
+      }
+    );
     if (
       this.options.changeDetectionStrategy ===
       ChangeDetectionStrategy.Subscriber
     ) {
+      this.logger.info(LOG_MESSAGE_CHANGE_TRACKING_ENABLED);
       this.registerSubscriber(connection);
     }
   }
 
   public async init(): Promise<void> {
+    const startTime = performance.now();
+    this.logger.info(LOG_MESSAGE_INITIALIZATION_STARTED, {
+      [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+    });
     await this.manager.transaction(async (em: EntityManager) => {
       await this.detectTables(em);
       await this.calculateDependencyTables(em);
@@ -55,16 +127,30 @@ export class Fastypest extends SQLScript {
         this.detectTablesWithAutoIncrement(em, tables),
       ]);
     });
+    this.logger.info(LOG_MESSAGE_INITIALIZATION_COMPLETED, {
+      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+        performance.now() - startTime
+      ),
+      [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+      [METADATA_KEY_TABLES_WITH_AUTO_INCREMENT]:
+        this.tablesWithAutoIncrement.size,
+    });
   }
 
   private async createTempTable(
     em: EntityManager,
     tables: string[]
   ): Promise<void> {
+    const totalTables = tables.length;
     await Promise.all(
-      tables.map(async (tableName) => {
+      tables.map(async (tableName, index) => {
         await this.execQuery(em, "dropTempTable", { tableName });
         await this.execQuery(em, "createTempTable", { tableName });
+        this.logger.debug(LOG_MESSAGE_TEMP_TABLES_PREPARED, {
+          [METADATA_KEY_TABLE]: tableName,
+          [METADATA_KEY_PROGRESS_CURRENT]: index + PROGRESS_OFFSET,
+          [METADATA_KEY_PROGRESS_TOTAL]: totalTables,
+        });
       })
     );
   }
@@ -73,20 +159,26 @@ export class Fastypest extends SQLScript {
     em: EntityManager,
     tables: string[]
   ): Promise<void> {
-    for (const tableName of tables) {
-      await this.processTable(em, tableName);
+    const totalTables = tables.length;
+    for (const [index, tableName] of tables.entries()) {
+      await this.processTable(em, tableName, index + PROGRESS_OFFSET, totalTables);
     }
+    this.logger.debug(LOG_MESSAGE_AUTO_INCREMENT_ANALYZED, {
+      [METADATA_KEY_TABLES_WITH_AUTO_INCREMENT]: this.tablesWithAutoIncrement.size,
+    });
   }
 
   private async processTable(
     em: EntityManager,
-    tableName: string
+    tableName: string,
+    position: number,
+    total: number
   ): Promise<void> {
     const columns = await this.getColumnsWithAutoIncrement(em, tableName);
     if (!columns) return;
 
     for (const column of columns) {
-      await this.processColumn(em, tableName, column);
+      await this.processColumn(em, tableName, column, position, total);
     }
   }
 
@@ -105,7 +197,9 @@ export class Fastypest extends SQLScript {
   private async processColumn(
     em: EntityManager,
     tableName: string,
-    column: ColumnsWithAutoIncrement
+    column: ColumnsWithAutoIncrement,
+    position: number,
+    total: number
   ): Promise<void> {
     const stat = await this.getMaxColumnIndex(
       em,
@@ -120,6 +214,13 @@ export class Fastypest extends SQLScript {
       column: column.column_name,
       sequenceName,
       index: String(index + (INDEX_OFFSET_CONFIG[this.getType()] ?? 0)),
+    });
+    this.logger.debug(LOG_MESSAGE_AUTO_INCREMENT_COLUMN, {
+      [METADATA_KEY_TABLE]: tableName,
+      [METADATA_KEY_COLUMNS]: column.column_name,
+      [METADATA_KEY_SEQUENCES]: sequenceName,
+      [METADATA_KEY_PROGRESS_CURRENT]: position,
+      [METADATA_KEY_PROGRESS_TOTAL]: total,
     });
   }
 
@@ -151,11 +252,30 @@ export class Fastypest extends SQLScript {
   }
 
   public async restoreData(): Promise<void> {
+    const startTime = performance.now();
+    const tablesToRestore = this.getTablesForRestore();
+    if (this.shouldTrackChanges() && this.changedTables.size === 0) {
+      this.logger.debug(LOG_MESSAGE_NO_CHANGES, {
+        [METADATA_KEY_TOTAL_TABLES]: tablesToRestore.length,
+      });
+    }
+    this.logger.info(LOG_MESSAGE_RESTORE_STARTED, {
+      [METADATA_KEY_TOTAL_TABLES]: tablesToRestore.length,
+      [METADATA_KEY_CHANGED_TABLES]: this.shouldTrackChanges()
+        ? this.changedTables.size
+        : undefined,
+    });
     await this.manager.transaction(async (em: EntityManager) => {
       const { foreignKey, restoreOrder } = await this.restoreManager(em);
       await foreignKey.disable();
       await restoreOrder();
       await foreignKey.enable();
+    });
+    this.logger.info(LOG_MESSAGE_RESTORE_COMPLETED, {
+      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+        performance.now() - startTime
+      ),
+      [METADATA_KEY_TABLES_RESTORED]: tablesToRestore.length,
     });
   }
 
@@ -174,10 +294,18 @@ export class Fastypest extends SQLScript {
 
     const typesWithForeignKey: DBType[] = ["postgres", "mariadb", "mysql"];
     if (typesWithForeignKey.includes(this.getType())) {
-      manager.foreignKey.disable = async (): Promise<void> =>
-        this.execQuery(em, "foreignKey.disable");
-      manager.foreignKey.enable = async (): Promise<void> =>
-        this.execQuery(em, "foreignKey.enable");
+      manager.foreignKey.disable = async (): Promise<void> => {
+        this.logger.debug(LOG_MESSAGE_FOREIGN_KEY_DISABLED, {
+          [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+        });
+        await this.execQuery(em, "foreignKey.disable");
+      };
+      manager.foreignKey.enable = async (): Promise<void> => {
+        await this.execQuery(em, "foreignKey.enable");
+        this.logger.debug(LOG_MESSAGE_FOREIGN_KEY_ENABLED, {
+          [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+        });
+      };
     }
 
     manager.restoreOrder = (): Promise<void> => this.restoreOrder(em);
@@ -186,6 +314,7 @@ export class Fastypest extends SQLScript {
   }
 
   private async calculateDependencyTables(em: EntityManager): Promise<void> {
+    const startTime = performance.now();
     const dependencyTree = await this.execQuery<DependencyTreeQueryOut>(
       em,
       "dependencyTree"
@@ -193,6 +322,13 @@ export class Fastypest extends SQLScript {
 
     if (!dependencyTree.length) {
       this.restoreInOder = false;
+      this.logger.debug(LOG_MESSAGE_DEPENDENCIES_READY, {
+        [METADATA_KEY_MODE]: RESTORE_MODE_PARALLEL,
+        [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+          performance.now() - startTime
+        ),
+        [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+      });
       return;
     }
 
@@ -200,26 +336,69 @@ export class Fastypest extends SQLScript {
     this.tables.clear();
     this.tables = sortedTables;
     this.restoreInOder = true;
+    this.logger.debug(LOG_MESSAGE_DEPENDENCIES_READY, {
+      [METADATA_KEY_MODE]: RESTORE_MODE_ORDERED,
+      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+        performance.now() - startTime
+      ),
+      [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+    });
   }
 
   private async detectTables(em: EntityManager): Promise<void> {
+    const startTime = performance.now();
     const tables = await this.execQuery<Table>(em, "getTables");
-    if (!tables) return;
+    if (!tables) {
+      this.logger.debug(LOG_MESSAGE_TABLES_DISCOVERED, {
+        [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+        [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+          performance.now() - startTime
+        ),
+      });
+      return;
+    }
 
     tables.forEach((row) => {
       this.tables.add(row.name);
+    });
+    this.logger.debug(LOG_MESSAGE_TABLES_DISCOVERED, {
+      [METADATA_KEY_TOTAL_TABLES]: this.tables.size,
+      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+        performance.now() - startTime
+      ),
     });
   }
 
   private async restoreOrder(em: EntityManager): Promise<void> {
     const tables = this.getTablesForRestore();
+    const totalTables = tables.length;
     if (this.restoreInOder) {
-      for (const tableName of tables) {
-        await this.recreateData(em, tableName);
+      this.logger.debug(LOG_MESSAGE_RESTORE_MODE, {
+        [METADATA_KEY_MODE]: RESTORE_MODE_ORDERED,
+        [METADATA_KEY_TOTAL_TABLES]: totalTables,
+      });
+      for (const [index, tableName] of tables.entries()) {
+        await this.recreateData(
+          em,
+          tableName,
+          index + PROGRESS_OFFSET,
+          totalTables
+        );
       }
     } else {
+      this.logger.debug(LOG_MESSAGE_RESTORE_MODE, {
+        [METADATA_KEY_MODE]: RESTORE_MODE_PARALLEL,
+        [METADATA_KEY_TOTAL_TABLES]: totalTables,
+      });
       await Promise.all(
-        tables.map((tableName) => this.recreateData(em, tableName))
+        tables.map((tableName, index) =>
+          this.recreateData(
+            em,
+            tableName,
+            index + PROGRESS_OFFSET,
+            totalTables
+          )
+        )
       );
     }
     if (this.shouldTrackChanges()) {
@@ -229,11 +408,37 @@ export class Fastypest extends SQLScript {
 
   private async recreateData(
     em: EntityManager,
-    tableName: string
+    tableName: string,
+    position: number,
+    total: number
   ): Promise<void> {
+    const startTime = performance.now();
+    this.logger.info(LOG_MESSAGE_RESTORING_TABLE, {
+      [METADATA_KEY_TABLE]: tableName,
+      [METADATA_KEY_PROGRESS_CURRENT]: position,
+      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    });
     await this.execQuery(em, "truncateTable", { tableName });
+    this.logger.debug(LOG_MESSAGE_TABLE_TRUNCATED, {
+      [METADATA_KEY_TABLE]: tableName,
+      [METADATA_KEY_PROGRESS_CURRENT]: position,
+      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    });
     await this.execQuery(em, "restoreData", { tableName });
+    this.logger.debug(LOG_MESSAGE_DATA_RESTORED, {
+      [METADATA_KEY_TABLE]: tableName,
+      [METADATA_KEY_PROGRESS_CURRENT]: position,
+      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    });
     await this.resetAutoIncrementColumns(em, tableName);
+    this.logger.info(LOG_MESSAGE_TABLE_RESTORED, {
+      [METADATA_KEY_TABLE]: tableName,
+      [METADATA_KEY_DURATION_SECONDS]: this.formatDuration(
+        performance.now() - startTime
+      ),
+      [METADATA_KEY_PROGRESS_CURRENT]: position,
+      [METADATA_KEY_PROGRESS_TOTAL]: total,
+    });
   }
 
   private async resetAutoIncrementColumns(
@@ -250,6 +455,12 @@ export class Fastypest extends SQLScript {
         sequenceName,
         index,
       });
+      this.logger.debug(LOG_MESSAGE_AUTO_INCREMENT_RESET, {
+        [METADATA_KEY_TABLE]: tableName,
+        [METADATA_KEY_COLUMNS]: column,
+        [METADATA_KEY_SEQUENCES]: sequenceName,
+        index,
+      });
     }
   }
 
@@ -259,6 +470,9 @@ export class Fastypest extends SQLScript {
     });
     this.getSubscriberCollection(connection).push(subscriber);
     this.bindSubscriber(subscriber, connection);
+    this.logger.info(LOG_MESSAGE_SUBSCRIBER_REGISTERED, {
+      [METADATA_KEY_DATABASE_TYPE]: this.getType(),
+    });
   }
 
   private isDataSource(
@@ -307,6 +521,10 @@ export class Fastypest extends SQLScript {
     if (filtered.length === 0) {
       return tables;
     }
+    this.logger.debug(LOG_MESSAGE_FILTERED_TABLES, {
+      [METADATA_KEY_CHANGED_TABLES]: filtered.length,
+      [METADATA_KEY_TOTAL_TABLES]: tables.length,
+    });
     return filtered;
   }
 
@@ -314,7 +532,34 @@ export class Fastypest extends SQLScript {
     if (!this.shouldTrackChanges()) {
       return;
     }
+    const wasTracked = this.changedTables.has(tableName);
     this.changedTables.add(tableName);
+    if (!wasTracked) {
+      this.logger.debug(LOG_MESSAGE_CHANGE_DETECTED, {
+        [METADATA_KEY_TABLE]: tableName,
+        [METADATA_KEY_CHANGED_TABLES]: this.changedTables.size,
+      });
+    }
+  }
+
+  private resolveLoggingConfiguration(
+    logging?: boolean | LoggingOptions
+  ): LoggingOptions | undefined {
+    if (typeof logging === "boolean") {
+      return { enabled: logging };
+    }
+    if (!logging) {
+      return undefined;
+    }
+    if (logging.enabled === undefined) {
+      return { ...logging, enabled: true };
+    }
+    return logging;
+  }
+
+  private formatDuration(milliseconds: number): number {
+    const seconds = milliseconds / MILLISECONDS_IN_SECOND;
+    return Number(seconds.toFixed(DURATION_PRECISION));
   }
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,5 @@
 export * from "./fastypest";
 export { ChangeDetectionStrategy } from "./types";
 export type { FastypestOptions } from "./types";
+export { LogLevel } from "../logging";
+export type { LoggingOptions } from "../logging";

--- a/src/core/sql-script/sql-script.ts
+++ b/src/core/sql-script/sql-script.ts
@@ -1,11 +1,18 @@
 import { DataSourceOptions, EntityManager } from "typeorm";
 import { AllowedDataBases, DB_QUERIES, Queries } from "./queries";
 import { QueryPath } from "./types";
+import { createScopedLogger } from "../../logging";
+
+const LOG_SCOPE_SQL_SCRIPT = "SQLScript";
+const LOG_MESSAGE_EXECUTING_QUERY = "Executing query";
+const METADATA_KEY_QUERY_PATH = "queryPath";
+const METADATA_KEY_VALUES = "values";
 
 type DBTypes = DataSourceOptions["type"];
 
 export class SQLScript {
   private queries: Queries;
+  private readonly scriptLogger = createScopedLogger(LOG_SCOPE_SQL_SCRIPT);
 
   protected constructor(private readonly type: DBTypes) {
     if (!(this.type in DB_QUERIES)) {
@@ -43,6 +50,10 @@ export class SQLScript {
       }
     }
 
+    this.scriptLogger.debug(LOG_MESSAGE_EXECUTING_QUERY, {
+      [METADATA_KEY_QUERY_PATH]: queryPath,
+      [METADATA_KEY_VALUES]: values,
+    });
     return em.query(query) as T extends void ? Promise<void> : Promise<T[]>;
   }
 }

--- a/src/core/sql-script/sql-script.ts
+++ b/src/core/sql-script/sql-script.ts
@@ -3,20 +3,11 @@ import { AllowedDataBases, DB_QUERIES, Queries } from "./queries";
 import { QueryPath } from "./types";
 import { createScopedLogger } from "../../logging";
 
-const LOG_SCOPE_SQL_SCRIPT = "SQLScript";
-const LOG_TEXT = {
-  executingQuery: "🧾 Executing query",
-} as const;
-const METADATA_KEYS = {
-  queryPath: "queryPath",
-  values: "values",
-} as const;
-
 type DBTypes = DataSourceOptions["type"];
 
 export class SQLScript {
   private queries: Queries;
-  private readonly scriptLogger = createScopedLogger(LOG_SCOPE_SQL_SCRIPT);
+  private readonly scriptLogger = createScopedLogger("SQLScript");
 
   protected constructor(private readonly type: DBTypes) {
     if (!(this.type in DB_QUERIES)) {
@@ -54,10 +45,14 @@ export class SQLScript {
       }
     }
 
-    this.scriptLogger.debug(LOG_TEXT.executingQuery, {
-      [METADATA_KEYS.queryPath]: queryPath,
-      [METADATA_KEYS.values]: values,
-    });
+    const parameterEntries = values
+      ? Object.entries(values).map(([key, value]) => `${key}=${value}`)
+      : [];
+    this.scriptLogger.debug(
+      "Executing SQL query",
+      `Path ${queryPath}`,
+      parameterEntries.length > 0 ? `Parameters ${parameterEntries.join(", ")}` : undefined
+    );
     return em.query(query) as T extends void ? Promise<void> : Promise<T[]>;
   }
 }

--- a/src/core/sql-script/sql-script.ts
+++ b/src/core/sql-script/sql-script.ts
@@ -4,9 +4,13 @@ import { QueryPath } from "./types";
 import { createScopedLogger } from "../../logging";
 
 const LOG_SCOPE_SQL_SCRIPT = "SQLScript";
-const LOG_MESSAGE_EXECUTING_QUERY = "Executing query";
-const METADATA_KEY_QUERY_PATH = "queryPath";
-const METADATA_KEY_VALUES = "values";
+const LOG_TEXT = {
+  executingQuery: "🧾 Executing query",
+} as const;
+const METADATA_KEYS = {
+  queryPath: "queryPath",
+  values: "values",
+} as const;
 
 type DBTypes = DataSourceOptions["type"];
 
@@ -50,9 +54,9 @@ export class SQLScript {
       }
     }
 
-    this.scriptLogger.debug(LOG_MESSAGE_EXECUTING_QUERY, {
-      [METADATA_KEY_QUERY_PATH]: queryPath,
-      [METADATA_KEY_VALUES]: values,
+    this.scriptLogger.debug(LOG_TEXT.executingQuery, {
+      [METADATA_KEYS.queryPath]: queryPath,
+      [METADATA_KEYS.values]: values,
     });
     return em.query(query) as T extends void ? Promise<void> : Promise<T[]>;
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
 import { DataSourceOptions } from "typeorm";
+import type { LoggingOptions } from "../logging";
 
 export type Table = { name: string };
 export type DependencyTreeQueryOut = {
@@ -13,6 +14,7 @@ export enum ChangeDetectionStrategy {
 
 export type FastypestOptions = {
   changeDetectionStrategy?: ChangeDetectionStrategy;
+  logging?: boolean | LoggingOptions;
 };
 
 export type ColumnsWithAutoIncrement = {

--- a/src/logging/constants.ts
+++ b/src/logging/constants.ts
@@ -1,0 +1,32 @@
+export enum LogLevel {
+  Error = "error",
+  Warn = "warn",
+  Info = "info",
+  Debug = "debug",
+}
+
+export const LOGGING_DEFAULT_ENABLED = false;
+export const LOGGING_DEFAULT_LEVEL = LogLevel.Info;
+export const LOGGING_TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
+export const LOGGING_LEVEL_WEIGHTS: Record<LogLevel, number> = {
+  [LogLevel.Error]: 0,
+  [LogLevel.Warn]: 1,
+  [LogLevel.Info]: 2,
+  [LogLevel.Debug]: 3,
+};
+export const LOGGING_COLORS: Record<LogLevel, string> = {
+  [LogLevel.Error]: "red",
+  [LogLevel.Warn]: "yellow",
+  [LogLevel.Info]: "cyan",
+  [LogLevel.Debug]: "magenta",
+};
+
+export type LoggingOptions = {
+  enabled?: boolean;
+  level?: LogLevel;
+};
+
+export type ResolvedLoggingOptions = {
+  enabled: boolean;
+  level: LogLevel;
+};

--- a/src/logging/constants.ts
+++ b/src/logging/constants.ts
@@ -1,40 +1,51 @@
 export enum LogLevel {
   Error = "error",
   Warn = "warn",
+  Log = "notice",
   Info = "info",
   Debug = "debug",
+  Verbose = "verbose",
 }
 
 export const LOGGING_DEFAULT_ENABLED = false;
-export const LOGGING_DEFAULT_LEVEL = LogLevel.Info;
+export const LOGGING_DEFAULT_LEVEL = LogLevel.Log;
 export const LOGGING_TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
+
 export const LOGGING_LEVEL_WEIGHTS: Record<LogLevel, number> = {
   [LogLevel.Error]: 0,
   [LogLevel.Warn]: 1,
-  [LogLevel.Info]: 2,
-  [LogLevel.Debug]: 3,
+  [LogLevel.Log]: 2,
+  [LogLevel.Info]: 3,
+  [LogLevel.Debug]: 4,
+  [LogLevel.Verbose]: 5,
 };
+
 export const LOGGING_COLORS: Record<LogLevel, string> = {
   [LogLevel.Error]: "bold red",
   [LogLevel.Warn]: "bold yellow",
-  [LogLevel.Info]: "bold green",
-  [LogLevel.Debug]: "bold cyan",
+  [LogLevel.Log]: "bold green",
+  [LogLevel.Info]: "bold cyan",
+  [LogLevel.Debug]: "bold magenta",
+  [LogLevel.Verbose]: "bold blue",
 };
+
 export const LOGGING_LEVEL_ICONS: Record<LogLevel, string> = {
   [LogLevel.Error]: "❌",
   [LogLevel.Warn]: "⚠️",
-  [LogLevel.Info]: "ℹ️",
-  [LogLevel.Debug]: "🔍",
+  [LogLevel.Log]: "🟢",
+  [LogLevel.Info]: "💡",
+  [LogLevel.Debug]: "🧭",
+  [LogLevel.Verbose]: "🌀",
 };
+
 export const LOGGING_LEVEL_LABELS: Record<LogLevel, string> = {
   [LogLevel.Error]: "ERROR",
   [LogLevel.Warn]: "WARN",
+  [LogLevel.Log]: "LOG",
   [LogLevel.Info]: "INFO",
   [LogLevel.Debug]: "DEBUG",
+  [LogLevel.Verbose]: "VERBOSE",
 };
-export const LOGGING_METADATA_SEPARATOR = " | ";
-export const LOGGING_METADATA_KEY_VALUE_SEPARATOR = ": ";
-export const LOGGING_DEFAULT_SCOPE = "Fastypest";
 
 export type LoggingOptions = {
   enabled?: boolean;

--- a/src/logging/constants.ts
+++ b/src/logging/constants.ts
@@ -15,11 +15,26 @@ export const LOGGING_LEVEL_WEIGHTS: Record<LogLevel, number> = {
   [LogLevel.Debug]: 3,
 };
 export const LOGGING_COLORS: Record<LogLevel, string> = {
-  [LogLevel.Error]: "red",
-  [LogLevel.Warn]: "yellow",
-  [LogLevel.Info]: "cyan",
-  [LogLevel.Debug]: "magenta",
+  [LogLevel.Error]: "bold red",
+  [LogLevel.Warn]: "bold yellow",
+  [LogLevel.Info]: "bold green",
+  [LogLevel.Debug]: "bold cyan",
 };
+export const LOGGING_LEVEL_ICONS: Record<LogLevel, string> = {
+  [LogLevel.Error]: "❌",
+  [LogLevel.Warn]: "⚠️",
+  [LogLevel.Info]: "ℹ️",
+  [LogLevel.Debug]: "🔍",
+};
+export const LOGGING_LEVEL_LABELS: Record<LogLevel, string> = {
+  [LogLevel.Error]: "ERROR",
+  [LogLevel.Warn]: "WARN",
+  [LogLevel.Info]: "INFO",
+  [LogLevel.Debug]: "DEBUG",
+};
+export const LOGGING_METADATA_SEPARATOR = " | ";
+export const LOGGING_METADATA_KEY_VALUE_SEPARATOR = ": ";
+export const LOGGING_DEFAULT_SCOPE = "Fastypest";
 
 export type LoggingOptions = {
   enabled?: boolean;

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,0 +1,13 @@
+export {
+  configureLogging,
+  createScopedLogger,
+  ScopedLogger,
+  getLoggingOptions,
+} from "./logger";
+export {
+  LogLevel,
+  LOGGING_DEFAULT_ENABLED,
+  LOGGING_DEFAULT_LEVEL,
+  type LoggingOptions,
+  type ResolvedLoggingOptions,
+} from "./constants";

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -8,6 +8,7 @@ export {
   LogLevel,
   LOGGING_DEFAULT_ENABLED,
   LOGGING_DEFAULT_LEVEL,
+  LOGGING_LEVEL_LABELS,
   type LoggingOptions,
   type ResolvedLoggingOptions,
 } from "./constants";

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,0 +1,137 @@
+import { addColors, createLogger, format, transports } from "winston";
+import {
+  LOGGING_COLORS,
+  LOGGING_DEFAULT_ENABLED,
+  LOGGING_DEFAULT_LEVEL,
+  LOGGING_LEVEL_WEIGHTS,
+  LOGGING_TIMESTAMP_FORMAT,
+  LogLevel,
+  type LoggingOptions,
+  type ResolvedLoggingOptions,
+} from "./constants";
+
+type LogMetadata = Record<string, unknown>;
+type LoggerInfo = Record<string, unknown>;
+
+const LOG_FIELD_LABEL = "label";
+const LOG_FIELD_METADATA = "metadata";
+const LOG_FIELD_MESSAGE = "message";
+const LOG_FIELD_LEVEL = "level";
+const LOG_FIELD_TIMESTAMP = "timestamp";
+const LOGGER_SCOPE_DEFAULT = "Fastypest";
+
+const formatLogMessage = (info: LoggerInfo): string => {
+  const label = info[LOG_FIELD_LABEL] as string | undefined;
+  const metadata = info[LOG_FIELD_METADATA] as LogMetadata | undefined;
+  const metadataText = metadata && Object.keys(metadata).length > 0 ? ` ${JSON.stringify(metadata)}` : "";
+  const timestamp = info[LOG_FIELD_TIMESTAMP] as string | undefined;
+  const level = String(info[LOG_FIELD_LEVEL] ?? "");
+  const message = String(info[LOG_FIELD_MESSAGE] ?? "");
+  const timestampText = timestamp ? `${timestamp} ` : "";
+  return `${timestampText}[${label ?? LOGGER_SCOPE_DEFAULT}] ${level}: ${message}${metadataText}`;
+};
+
+addColors(LOGGING_COLORS);
+
+const baseLogger = createLogger({
+  levels: LOGGING_LEVEL_WEIGHTS,
+  level: LogLevel.Debug,
+  format: format.combine(
+    format.timestamp({ format: LOGGING_TIMESTAMP_FORMAT }),
+    format.metadata({ fillExcept: [LOG_FIELD_MESSAGE, LOG_FIELD_LEVEL, LOG_FIELD_TIMESTAMP, LOG_FIELD_LABEL] }),
+    format.colorize({ all: true }),
+    format.printf((info) => formatLogMessage(info as LoggerInfo))
+  ),
+  transports: [new transports.Console()],
+  silent: false,
+});
+
+let globalOptions: ResolvedLoggingOptions = {
+  enabled: LOGGING_DEFAULT_ENABLED,
+  level: LOGGING_DEFAULT_LEVEL,
+};
+
+const resolveEnabled = (enabled: boolean | undefined, hasOptions: boolean): boolean => {
+  if (enabled !== undefined) {
+    return enabled;
+  }
+  if (hasOptions) {
+    return true;
+  }
+  return LOGGING_DEFAULT_ENABLED;
+};
+
+const resolveLoggingOptions = (options?: LoggingOptions): ResolvedLoggingOptions => {
+  const hasOptions = Boolean(options);
+  return {
+    enabled: resolveEnabled(options?.enabled, hasOptions),
+    level: options?.level ?? LOGGING_DEFAULT_LEVEL,
+  };
+};
+
+const shouldLog = (level: LogLevel, options: ResolvedLoggingOptions): boolean => {
+  if (!options.enabled) {
+    return false;
+  }
+  return LOGGING_LEVEL_WEIGHTS[level] <= LOGGING_LEVEL_WEIGHTS[options.level];
+};
+
+const mergeOptions = (local?: LoggingOptions): ResolvedLoggingOptions => {
+  if (!local) {
+    return globalOptions;
+  }
+  const resolvedLocal = resolveLoggingOptions(local);
+  const level = local.level !== undefined ? resolvedLocal.level : globalOptions.level;
+  return {
+    enabled: resolvedLocal.enabled,
+    level,
+  };
+};
+
+const logWithMetadata = (
+  level: LogLevel,
+  scope: string,
+  message: string,
+  metadata: LogMetadata | undefined,
+  options: ResolvedLoggingOptions
+): void => {
+  if (!shouldLog(level, options)) {
+    return;
+  }
+  baseLogger.log({
+    level,
+    message,
+    [LOG_FIELD_LABEL]: scope,
+    [LOG_FIELD_METADATA]: metadata ?? {},
+  });
+};
+
+export const configureLogging = (options?: LoggingOptions): ResolvedLoggingOptions => {
+  globalOptions = resolveLoggingOptions(options);
+  return globalOptions;
+};
+
+export class ScopedLogger {
+  constructor(private readonly scope: string, private readonly localOptions?: LoggingOptions) {}
+
+  public error(message: string, metadata?: LogMetadata): void {
+    logWithMetadata(LogLevel.Error, this.scope, message, metadata, mergeOptions(this.localOptions));
+  }
+
+  public warn(message: string, metadata?: LogMetadata): void {
+    logWithMetadata(LogLevel.Warn, this.scope, message, metadata, mergeOptions(this.localOptions));
+  }
+
+  public info(message: string, metadata?: LogMetadata): void {
+    logWithMetadata(LogLevel.Info, this.scope, message, metadata, mergeOptions(this.localOptions));
+  }
+
+  public debug(message: string, metadata?: LogMetadata): void {
+    logWithMetadata(LogLevel.Debug, this.scope, message, metadata, mergeOptions(this.localOptions));
+  }
+}
+
+export const createScopedLogger = (scope: string, options?: LoggingOptions): ScopedLogger =>
+  new ScopedLogger(scope, options);
+
+export const getLoggingOptions = (): ResolvedLoggingOptions => ({ ...globalOptions });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,32 +1,117 @@
+import { performance } from "node:perf_hooks";
 import { addColors, createLogger, format, transports } from "winston";
 import {
   LOGGING_COLORS,
   LOGGING_DEFAULT_ENABLED,
   LOGGING_DEFAULT_LEVEL,
-  LOGGING_DEFAULT_SCOPE,
   LOGGING_LEVEL_ICONS,
   LOGGING_LEVEL_LABELS,
   LOGGING_LEVEL_WEIGHTS,
-  LOGGING_METADATA_KEY_VALUE_SEPARATOR,
-  LOGGING_METADATA_SEPARATOR,
   LOGGING_TIMESTAMP_FORMAT,
   LogLevel,
   type LoggingOptions,
   type ResolvedLoggingOptions,
 } from "./constants";
 
-type LogMetadata = Record<string, unknown>;
-type LoggerInfo = Record<string, unknown> & {
-  level: string;
-  message: string;
-};
-
 const LOG_FIELD_LABEL = "label";
-const LOG_FIELD_METADATA = "metadata";
 const LOG_FIELD_MESSAGE = "message";
 const LOG_FIELD_LEVEL = "level";
 const LOG_FIELD_TIMESTAMP = "timestamp";
+const LOG_FIELD_DETAILS = "details";
 const ANSI_ESCAPE_PATTERN = /\u001b\[[0-9;]*m/g;
+const DETAIL_SEPARATOR = " · ";
+const DETAIL_PREFIX = " — ";
+const MILLISECONDS_IN_SECOND = 1000;
+const SECONDS_IN_MINUTE = 60;
+const MINUTES_IN_HOUR = 60;
+const MILLISECONDS_IN_MINUTE = MILLISECONDS_IN_SECOND * SECONDS_IN_MINUTE;
+const MILLISECONDS_IN_HOUR = MILLISECONDS_IN_MINUTE * MINUTES_IN_HOUR;
+const DECIMAL_PRECISION_SHORT = 2;
+const DECIMAL_PRECISION_LONG = 1;
+
+const formatDetailValue = (detail: LogDetail): string | undefined => {
+  if (detail === undefined) {
+    return undefined;
+  }
+  if (detail === null) {
+    return "null";
+  }
+  if (detail instanceof Date) {
+    return detail.toISOString();
+  }
+  if (detail instanceof Error) {
+    return detail.message;
+  }
+  if (typeof detail === "boolean") {
+    return detail ? "yes" : "no";
+  }
+  return String(detail);
+};
+
+const trimDecimals = (value: number): string => {
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return value.toString();
+};
+
+const formatSeconds = (seconds: number): string => {
+  const precision = seconds < 10 ? DECIMAL_PRECISION_SHORT : DECIMAL_PRECISION_LONG;
+  const rounded = Number(seconds.toFixed(precision));
+  return `${trimDecimals(rounded)}s`;
+};
+
+const formatDurationText = (durationMs: number): string => {
+  if (durationMs <= 0) {
+    return "0ms";
+  }
+  const segments: string[] = [];
+  const hours = Math.floor(durationMs / MILLISECONDS_IN_HOUR);
+  let remaining = durationMs - hours * MILLISECONDS_IN_HOUR;
+  const minutes = Math.floor(remaining / MILLISECONDS_IN_MINUTE);
+  remaining -= minutes * MILLISECONDS_IN_MINUTE;
+  const seconds = remaining / MILLISECONDS_IN_SECOND;
+  const wholeSeconds = Math.floor(seconds);
+  const leftoverMs = Math.round(remaining - wholeSeconds * MILLISECONDS_IN_SECOND);
+
+  if (hours > 0) {
+    segments.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    segments.push(`${minutes}m`);
+  }
+  if (hours > 0 || minutes > 0) {
+    if (wholeSeconds > 0) {
+      segments.push(`${wholeSeconds}s`);
+    }
+    if (segments.length === 0 || leftoverMs > 0) {
+      if (leftoverMs > 0) {
+        segments.push(`${leftoverMs}ms`);
+      }
+    }
+  } else if (seconds >= 1) {
+    segments.push(formatSeconds(seconds));
+  } else {
+    segments.push(`${Math.round(durationMs)}ms`);
+  }
+  return segments.join(" ");
+};
+
+type LogDetail = string | number | boolean | bigint | Date | Error | null | undefined;
+
+type LogDetailsInput = LogDetail | LogDetail[];
+
+type LoggerInfo = Record<string, unknown> & {
+  level: string;
+  message: string;
+  [LOG_FIELD_DETAILS]?: string;
+};
+
+type LoggerPayload = LoggerInfo & {
+  [LOG_FIELD_LABEL]: string;
+};
+
+type TimerEmitter = (level: LogLevel, message: string, details: LogDetail[]) => void;
 
 const extractLevel = (info: LoggerInfo): LogLevel | undefined => {
   const levelText = (info[LOG_FIELD_LEVEL] as string | undefined) ?? info.level;
@@ -36,61 +121,38 @@ const extractLevel = (info: LoggerInfo): LogLevel | undefined => {
   const normalized = levelText.replace(ANSI_ESCAPE_PATTERN, "").toLowerCase();
   return normalized in LOGGING_LEVEL_WEIGHTS ? (normalized as LogLevel) : undefined;
 };
-const formatValue = (value: unknown): string => {
-  if (value === undefined) {
-    return "undefined";
-  }
-  if (value === null) {
-    return "null";
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => formatValue(entry)).join(", ");
-  }
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  if (typeof value === "object") {
-    return JSON.stringify(value);
-  }
-  return String(value);
-};
 
-const formatMetadata = (metadata: LogMetadata | undefined): string => {
-  if (!metadata) {
-    return "";
+const formatDetails = (details: LogDetail[]): string | undefined => {
+  const formatted = details
+    .map((detail) => formatDetailValue(detail))
+    .filter((value): value is string => Boolean(value && value.length > 0));
+  if (formatted.length === 0) {
+    return undefined;
   }
-  const entries = Object.entries(metadata);
-  if (entries.length === 0) {
-    return "";
-  }
-  return entries
-    .map(([key, value]) => `${key}${LOGGING_METADATA_KEY_VALUE_SEPARATOR}${formatValue(value)}`)
-    .join(LOGGING_METADATA_SEPARATOR);
+  return formatted.join(DETAIL_SEPARATOR);
 };
 
 const formatLogMessage = (info: LoggerInfo): string => {
   const label = info[LOG_FIELD_LABEL] as string | undefined;
-  const metadata = info[LOG_FIELD_METADATA] as LogMetadata | undefined;
   const timestamp = info[LOG_FIELD_TIMESTAMP] as string | undefined;
   const level = extractLevel(info);
   const fallbackLevel = info.level.replace(ANSI_ESCAPE_PATTERN, "").toUpperCase();
   const message = info[LOG_FIELD_MESSAGE] ? String(info[LOG_FIELD_MESSAGE]) : info.message;
   const levelLabel = level ? LOGGING_LEVEL_LABELS[level] : fallbackLevel;
   const levelIcon = level ? `${LOGGING_LEVEL_ICONS[level]} ` : "";
-  const metadataText = formatMetadata(metadata);
-  const formattedMetadata = metadataText ? `${LOGGING_METADATA_SEPARATOR}${metadataText}` : "";
+  const detailText = info[LOG_FIELD_DETAILS] ? String(info[LOG_FIELD_DETAILS]) : "";
+  const formattedDetails = detailText ? `${DETAIL_PREFIX}${detailText}` : "";
   const timestampText = timestamp ? `${timestamp} ` : "";
-  return `${timestampText}${levelIcon}[${label ?? LOGGING_DEFAULT_SCOPE}] ${levelLabel} ${message}${formattedMetadata}`;
+  return `${timestampText}${levelIcon}[${label ?? ""}] ${levelLabel} ${message}${formattedDetails}`;
 };
 
 addColors(LOGGING_COLORS);
 
 const baseLogger = createLogger({
   levels: LOGGING_LEVEL_WEIGHTS,
-  level: LogLevel.Debug,
+  level: LogLevel.Verbose,
   format: format.combine(
     format.timestamp({ format: LOGGING_TIMESTAMP_FORMAT }),
-    format.metadata({ fillExcept: [LOG_FIELD_MESSAGE, LOG_FIELD_LEVEL, LOG_FIELD_TIMESTAMP, LOG_FIELD_LABEL] }),
     format.colorize({ all: true }),
     format.printf((info: unknown) => formatLogMessage(info as LoggerInfo))
   ),
@@ -140,27 +202,33 @@ const mergeOptions = (local?: LoggingOptions): ResolvedLoggingOptions => {
   };
 };
 
-const logWithMetadata = (
+const normalizeDetails = (input: LogDetailsInput[]): LogDetail[] => {
+  return input.flatMap((entry) => {
+    if (Array.isArray(entry)) {
+      return entry;
+    }
+    return [entry];
+  });
+};
+
+const logWithDetails = (
   level: LogLevel,
   scope: string,
   message: string,
-  metadata: LogMetadata | undefined,
+  details: LogDetail[],
   options: ResolvedLoggingOptions
 ): void => {
   if (!shouldLog(level, options)) {
     return;
   }
-  const metadataEntries = metadata ? Object.entries(metadata) : [];
-  const logPayload: LoggerInfo = {
+  const formattedDetails = formatDetails(details);
+  const logPayload: LoggerPayload = {
     level,
     message,
     [LOG_FIELD_LABEL]: scope,
   };
-  if (metadataEntries.length > 0) {
-    logPayload[LOG_FIELD_METADATA] = metadataEntries.reduce<LogMetadata>((accumulator, [key, value]) => {
-      accumulator[key] = value;
-      return accumulator;
-    }, {});
+  if (formattedDetails) {
+    logPayload[LOG_FIELD_DETAILS] = formattedDetails;
   }
   baseLogger.log(logPayload);
 };
@@ -170,23 +238,90 @@ export const configureLogging = (options?: LoggingOptions): ResolvedLoggingOptio
   return globalOptions;
 };
 
+export class LoggerTimer {
+  private readonly start = performance.now();
+  private lastMark = this.start;
+  private finished = false;
+
+  constructor(
+    private readonly label: string,
+    private readonly emit: TimerEmitter
+  ) {}
+
+  public mark(message: string, level: LogLevel = LogLevel.Debug, ...details: LogDetailsInput[]): void {
+    if (this.finished) {
+      return;
+    }
+    const now = performance.now();
+    const totalElapsed = now - this.start;
+    const segmentElapsed = now - this.lastMark;
+    this.lastMark = now;
+    const timerDetails: LogDetail[] = [
+      `${this.label} total ${formatDurationText(totalElapsed)}`,
+    ];
+    if (segmentElapsed > 0 && segmentElapsed !== totalElapsed) {
+      timerDetails.push(`segment ${formatDurationText(segmentElapsed)}`);
+    }
+    const normalized = normalizeDetails(details);
+    this.emit(level, message, [...timerDetails, ...normalized]);
+  }
+
+  public end(
+    message?: string,
+    level: LogLevel = LogLevel.Info,
+    ...details: LogDetailsInput[]
+  ): void {
+    if (this.finished) {
+      return;
+    }
+    const totalElapsed = performance.now() - this.start;
+    const normalized = normalizeDetails(details);
+    const timerDetails: LogDetail[] = [`${this.label} total ${formatDurationText(totalElapsed)}`];
+    this.emit(level, message ?? `${this.label} completed`, [...timerDetails, ...normalized]);
+    this.finished = true;
+  }
+}
+
 export class ScopedLogger {
   constructor(private readonly scope: string, private readonly localOptions?: LoggingOptions) {}
 
-  public error(message: string, metadata?: LogMetadata): void {
-    logWithMetadata(LogLevel.Error, this.scope, message, metadata, mergeOptions(this.localOptions));
+  public error(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Error, message, details);
   }
 
-  public warn(message: string, metadata?: LogMetadata): void {
-    logWithMetadata(LogLevel.Warn, this.scope, message, metadata, mergeOptions(this.localOptions));
+  public warn(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Warn, message, details);
   }
 
-  public info(message: string, metadata?: LogMetadata): void {
-    logWithMetadata(LogLevel.Info, this.scope, message, metadata, mergeOptions(this.localOptions));
+  public log(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Log, message, details);
   }
 
-  public debug(message: string, metadata?: LogMetadata): void {
-    logWithMetadata(LogLevel.Debug, this.scope, message, metadata, mergeOptions(this.localOptions));
+  public info(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Info, message, details);
+  }
+
+  public debug(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Debug, message, details);
+  }
+
+  public verbose(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Verbose, message, details);
+  }
+
+  public timer(label: string): LoggerTimer {
+    return new LoggerTimer(label, (level, message, details) => {
+      this.write(level, message, details);
+    });
+  }
+
+  public formatDuration(durationMs: number): string {
+    return formatDurationText(durationMs);
+  }
+
+  private write(level: LogLevel, message: string, details: LogDetailsInput[]): void {
+    const normalized = normalizeDetails(details);
+    logWithDetails(level, this.scope, message, normalized, mergeOptions(this.localOptions));
   }
 }
 

--- a/tests/config/global.setup.ts
+++ b/tests/config/global.setup.ts
@@ -1,15 +1,28 @@
+import { performance } from "node:perf_hooks";
+import { createScopedLogger } from "../../src/logging";
 import { seed } from "../seeds/seed";
 import { prepareDatabase } from "./orm.config";
 
+const LOG_SCOPE = "GlobalSetup";
+const LOG_MESSAGE_INITIALIZING_DATABASE = "Initializing database";
+const LOG_MESSAGE_SEEDING_DATABASE = "Seeding database";
+const LOG_MESSAGE_DATABASE_SEEDED = "Database seeded";
+const METADATA_KEY_DURATION_SECONDS = "durationInSeconds";
+const MILLISECONDS_IN_SECOND = 1000;
+const DURATION_PRECISION = 2;
+
+const logger = createScopedLogger(LOG_SCOPE, { enabled: true });
+
 const init = async () => {
-  console.log("\nInitializing database...");
+  logger.info(LOG_MESSAGE_INITIALIZING_DATABASE);
   const connection = await prepareDatabase();
-  console.log("Seeding database...");
-  const startTime = Date.now();
+  logger.info(LOG_MESSAGE_SEEDING_DATABASE);
+  const startTime = performance.now();
   await seed(connection);
-  const endTime = Date.now();
-  const totalTime = (endTime - startTime) / 1000;
-  console.log(`Database seeded in ${totalTime} seconds`);
+  const totalTime = (performance.now() - startTime) / MILLISECONDS_IN_SECOND;
+  logger.info(LOG_MESSAGE_DATABASE_SEEDED, {
+    [METADATA_KEY_DURATION_SECONDS]: Number(totalTime.toFixed(DURATION_PRECISION)),
+  });
   await connection.destroy();
 };
 

--- a/tests/config/global.setup.ts
+++ b/tests/config/global.setup.ts
@@ -4,24 +4,30 @@ import { seed } from "../seeds/seed";
 import { prepareDatabase } from "./orm.config";
 
 const LOG_SCOPE = "GlobalSetup";
-const LOG_MESSAGE_INITIALIZING_DATABASE = "Initializing database";
-const LOG_MESSAGE_SEEDING_DATABASE = "Seeding database";
-const LOG_MESSAGE_DATABASE_SEEDED = "Database seeded";
-const METADATA_KEY_DURATION_SECONDS = "durationInSeconds";
+const LOG_TEXT = {
+  initializingDatabase: "⚙️ Initializing database",
+  seedingDatabase: "🌱 Seeding database",
+  databaseSeeded: "✅ Database seeded",
+} as const;
+const METADATA_KEYS = {
+  durationSeconds: "durationInSeconds",
+} as const;
 const MILLISECONDS_IN_SECOND = 1000;
 const DURATION_PRECISION = 2;
 
 const logger = createScopedLogger(LOG_SCOPE, { enabled: true });
 
 const init = async () => {
-  logger.info(LOG_MESSAGE_INITIALIZING_DATABASE);
+  logger.info(LOG_TEXT.initializingDatabase);
   const connection = await prepareDatabase();
-  logger.info(LOG_MESSAGE_SEEDING_DATABASE);
+  logger.info(LOG_TEXT.seedingDatabase);
   const startTime = performance.now();
   await seed(connection);
   const totalTime = (performance.now() - startTime) / MILLISECONDS_IN_SECOND;
-  logger.info(LOG_MESSAGE_DATABASE_SEEDED, {
-    [METADATA_KEY_DURATION_SECONDS]: Number(totalTime.toFixed(DURATION_PRECISION)),
+  logger.info(LOG_TEXT.databaseSeeded, {
+    [METADATA_KEYS.durationSeconds]: Number(
+      totalTime.toFixed(DURATION_PRECISION)
+    ),
   });
   await connection.destroy();
 };

--- a/tests/config/global.setup.ts
+++ b/tests/config/global.setup.ts
@@ -1,35 +1,22 @@
-import { performance } from "node:perf_hooks";
-import { createScopedLogger } from "../../src/logging";
+import { createScopedLogger, LogLevel } from "../../src/logging";
 import { seed } from "../seeds/seed";
 import { prepareDatabase } from "./orm.config";
 
-const LOG_SCOPE = "GlobalSetup";
-const LOG_TEXT = {
-  initializingDatabase: "⚙️ Initializing database",
-  seedingDatabase: "🌱 Seeding database",
-  databaseSeeded: "✅ Database seeded",
-} as const;
-const METADATA_KEYS = {
-  durationSeconds: "durationInSeconds",
-} as const;
-const MILLISECONDS_IN_SECOND = 1000;
-const DURATION_PRECISION = 2;
-
-const logger = createScopedLogger(LOG_SCOPE, { enabled: true });
+const logger = createScopedLogger("GlobalSetup", { enabled: true });
 
 const init = async () => {
-  logger.info(LOG_TEXT.initializingDatabase);
+  logger.verbose("⚙️ Preparing database for test suite");
   const connection = await prepareDatabase();
-  logger.info(LOG_TEXT.seedingDatabase);
-  const startTime = performance.now();
+  const timer = logger.timer("Database seeding");
+  logger.debug("🌱 Seeding database with fixtures");
   await seed(connection);
-  const totalTime = (performance.now() - startTime) / MILLISECONDS_IN_SECOND;
-  logger.info(LOG_TEXT.databaseSeeded, {
-    [METADATA_KEYS.durationSeconds]: Number(
-      totalTime.toFixed(DURATION_PRECISION)
-    ),
-  });
+  timer.end(
+    "✅ Database seeded",
+    LogLevel.Info,
+    "Seeding completed for global setup"
+  );
   await connection.destroy();
+  logger.log("🧹 Database connection closed after seeding");
 };
 
 export default init;

--- a/tests/config/jest.setup.ts
+++ b/tests/config/jest.setup.ts
@@ -10,13 +10,7 @@ let fastypest: Fastypest;
 let connection: DataSource;
 
 const CHANGE_DETECTION_SPEC_BASENAME = "change-detection.spec.ts";
-const LOG_SCOPE = "JestSetup";
-const LOG_TEXT = {
-  skipSetup: "⏭️ Skipping default Fastypest setup",
-  skipRestore: "⏭️ Skipping default Fastypest restore",
-} as const;
-
-const logger = createScopedLogger(LOG_SCOPE, { enabled: true });
+const logger = createScopedLogger("JestSetup", { enabled: true });
 
 const shouldSkipDefaultFastypestSetup = (): boolean => {
   const testPath = expect.getState().testPath;
@@ -27,7 +21,7 @@ const shouldSkipDefaultFastypestSetup = (): boolean => {
 beforeAll(async () => {
   connection = await initialize();
   if (shouldSkipDefaultFastypestSetup()) {
-    logger.info(LOG_TEXT.skipSetup);
+    logger.warn("⏭️ Skipping default Fastypest setup");
     return;
   }
   fastypest = new Fastypest(connection);
@@ -36,7 +30,7 @@ beforeAll(async () => {
 
 afterEach(async () => {
   if (shouldSkipDefaultFastypestSetup()) {
-    logger.info(LOG_TEXT.skipRestore);
+    logger.warn("⏭️ Skipping default Fastypest restore");
     return;
   }
   await fastypest.restoreData();

--- a/tests/config/jest.setup.ts
+++ b/tests/config/jest.setup.ts
@@ -11,8 +11,10 @@ let connection: DataSource;
 
 const CHANGE_DETECTION_SPEC_BASENAME = "change-detection.spec.ts";
 const LOG_SCOPE = "JestSetup";
-const LOG_MESSAGE_SKIP_SETUP = "Skipping default fastypest setup";
-const LOG_MESSAGE_SKIP_RESTORE = "Skipping default fastypest restore";
+const LOG_TEXT = {
+  skipSetup: "⏭️ Skipping default Fastypest setup",
+  skipRestore: "⏭️ Skipping default Fastypest restore",
+} as const;
 
 const logger = createScopedLogger(LOG_SCOPE, { enabled: true });
 
@@ -25,7 +27,7 @@ const shouldSkipDefaultFastypestSetup = (): boolean => {
 beforeAll(async () => {
   connection = await initialize();
   if (shouldSkipDefaultFastypestSetup()) {
-    logger.info(LOG_MESSAGE_SKIP_SETUP);
+    logger.info(LOG_TEXT.skipSetup);
     return;
   }
   fastypest = new Fastypest(connection);
@@ -34,7 +36,7 @@ beforeAll(async () => {
 
 afterEach(async () => {
   if (shouldSkipDefaultFastypestSetup()) {
-    logger.info(LOG_MESSAGE_SKIP_RESTORE);
+    logger.info(LOG_TEXT.skipRestore);
     return;
   }
   await fastypest.restoreData();

--- a/tests/config/jest.setup.ts
+++ b/tests/config/jest.setup.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { DataSource } from "typeorm";
 import { Fastypest } from "../../dist/core";
+import { createScopedLogger } from "../../src/logging";
 import { initialize } from "./orm.config";
 
 jest.setTimeout(100_000);
@@ -9,6 +10,11 @@ let fastypest: Fastypest;
 let connection: DataSource;
 
 const CHANGE_DETECTION_SPEC_BASENAME = "change-detection.spec.ts";
+const LOG_SCOPE = "JestSetup";
+const LOG_MESSAGE_SKIP_SETUP = "Skipping default fastypest setup";
+const LOG_MESSAGE_SKIP_RESTORE = "Skipping default fastypest restore";
+
+const logger = createScopedLogger(LOG_SCOPE, { enabled: true });
 
 const shouldSkipDefaultFastypestSetup = (): boolean => {
   const testPath = expect.getState().testPath;
@@ -19,7 +25,7 @@ const shouldSkipDefaultFastypestSetup = (): boolean => {
 beforeAll(async () => {
   connection = await initialize();
   if (shouldSkipDefaultFastypestSetup()) {
-    console.log("Skipping default fastypest setup");
+    logger.info(LOG_MESSAGE_SKIP_SETUP);
     return;
   }
   fastypest = new Fastypest(connection);
@@ -28,7 +34,7 @@ beforeAll(async () => {
 
 afterEach(async () => {
   if (shouldSkipDefaultFastypestSetup()) {
-    console.log("Skipping default fastypest restore");
+    logger.info(LOG_MESSAGE_SKIP_RESTORE);
     return;
   }
   await fastypest.restoreData();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,6 +2314,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/winston@npm:^2.4.4":
+  version: 2.4.4
+  resolution: "@types/winston@npm:2.4.4"
+  dependencies:
+    winston: "npm:*"
+  checksum: 10c0/8b967c089ba71773cca671b76aba931b2849afb3a6c03cbc5ef04d19e44092e0957573c730cdfbdda71eeb44984d3554e7edb88391c2a3c1aa36cafadc8f2b87
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -5236,6 +5245,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.17"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.5.1"
+    "@types/winston": "npm:^2.4.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.44.0"
     "@typescript-eslint/parser": "npm:^8.44.1"
     "@typescript-eslint/types": "npm:8.44.1"
@@ -11147,7 +11157,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"winston@npm:^3.14.2":
+"winston@npm:*, winston@npm:^3.14.2":
   version: 3.17.0
   resolution: "winston@npm:3.17.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,6 +617,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: "npm:1.1.x"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: 10c0/a5133df8492802465ed01f2f0a5784585241a1030c362d54a602ed1839816d6c93d71dde05cf2ddb4fd0796238c19774406bd62fa2564b637907b495f52425fe
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3":
   version: 1.4.3
   resolution: "@emnapi/core@npm:1.4.3"
@@ -2289,6 +2307,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -3166,6 +3191,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.3":
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.7":
   version: 1.0.7
   resolution: "available-typed-arrays@npm:1.0.7"
@@ -3659,7 +3691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -3684,10 +3716,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: "npm:^1.0.0"
+    simple-swizzle: "npm:^0.2.2"
+  checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.3"
+    color-string: "npm:^1.6.0"
+  checksum: 10c0/39345d55825884c32a88b95127d417a2c24681d8b57069413596d9fcbb721459ef9d9ec24ce3e65527b5373ce171b73e38dbcd9c830a52a6487e7f37bf00e83c
   languageName: node
   linkType: hard
 
@@ -3695,6 +3747,16 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: "npm:^3.1.3"
+    text-hex: "npm:1.0.x"
+  checksum: 10c0/af5f91ff7f8e146b96e439ac20ed79b197210193bde721b47380a75b21751d90fa56390c773bb67c0aedd34ff85091883a437ab56861c779bd507d639ba7e123
   languageName: node
   linkType: hard
 
@@ -4374,6 +4436,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 10c0/3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
   languageName: node
   linkType: hard
 
@@ -5193,6 +5262,7 @@ __metadata:
     typeorm: "npm:^0.3.26"
     typescript: "npm:^5.9.2"
     typescript-eslint: "npm:^8.44.0"
+    winston: "npm:^3.14.2"
   peerDependencies:
     typeorm: ^0.3.26
   languageName: unknown
@@ -5216,6 +5286,13 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/45b559cff889934ebb8bc498351e5acba40750ada7e7d6bde197768d2fa67c149be8ae7f8ff34d03f4e1eb20f2764116e56440aaa2f6689e9a4aa7ef06acafe9
+  languageName: node
+  linkType: hard
+
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
   languageName: node
   linkType: hard
 
@@ -5344,6 +5421,13 @@ __metadata:
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 10c0/8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
   languageName: node
   linkType: hard
 
@@ -6191,6 +6275,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.4
+  resolution: "is-arrayish@npm:0.3.4"
+  checksum: 10c0/1fa672a2f0bedb74154440310f616c0b6e53a95cf0625522ae050f06626d1cabd1a3d8085c882dc45c61ad0e7df2529aff122810b3b4a552880bf170d6df94e0
   languageName: node
   linkType: hard
 
@@ -7403,6 +7494,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 10c0/0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
 "lefthook-darwin-arm64@npm:1.13.2":
   version: 1.13.2
   resolution: "lefthook-darwin-arm64@npm:1.13.2"
@@ -7660,6 +7758,20 @@ __metadata:
     strip-ansi: "npm:^7.1.0"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10c0/4b350c0a83d7753fea34dcac6cd797d1dc9603291565de009baa4aa91c0447eab0d3815a05c8ec9ac04fdfffb43c82adcdb03ec1fceafd8518e1a8c1cff4ff89
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "logform@npm:2.7.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/4789b4b37413c731d1835734cb799240d31b865afde6b7b3e06051d6a4127bfda9e88c99cfbf296d084a315ccbed2647796e6a56b66e725bcb268c586f57558f
   languageName: node
   linkType: hard
 
@@ -8312,6 +8424,15 @@ __metadata:
   dependencies:
     wrappy: "npm:1"
   checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 10c0/6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
   languageName: node
   linkType: hard
 
@@ -9096,7 +9217,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2":
+"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -9383,6 +9504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -9612,6 +9740,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "simple-swizzle@npm:0.2.4"
+  dependencies:
+    is-arrayish: "npm:^0.3.1"
+  checksum: 10c0/846c3fdd1325318d5c71295cfbb99bfc9edc4c8dffdda5e6e9efe30482bbcd32cf360fc2806f46ac43ff7d09bcfaff20337bb79f826f0e6a8e366efd3cdd7868
+  languageName: node
+  linkType: hard
+
 "slash@npm:3.0.0, slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -9819,6 +9956,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/e5a1e23a4057a86a97971465418f22ea89bd439ac36ade88812dd920e4e61873e8abd6a9b72a03a67ef50faa00a2daf1ab745c5a15b46d03e0544a0296354227
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
   languageName: node
   linkType: hard
 
@@ -10208,6 +10352,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
 "through2@npm:^2.0.0":
   version: 2.0.5
   resolution: "through2@npm:2.0.5"
@@ -10292,6 +10443,13 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: 10c0/03cfefde6c59ff57138412b8c6be922ecc5aec30694d784f2a65ef8dcbd47faef580b7de0c949345abdc56ec4b4abf64dd1e5aea619b200316e471a3dd5bf1f6
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 10c0/4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
   languageName: node
   linkType: hard
 
@@ -10975,6 +11133,36 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/449fa5c44ed120ccecfe18c433296a4978a7583bf2391c50abce13f76878d2476defde04d0f79db8165bdf432853c1f8389d0485ca6e8ebce3bbcded513d5e6a
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "winston-transport@npm:4.9.0"
+  dependencies:
+    logform: "npm:^2.7.0"
+    readable-stream: "npm:^3.6.2"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/e2990a172e754dbf27e7823772214a22dc8312f7ec9cfba831e5ef30a5d5528792e5ea8f083c7387ccfc5b2af20e3691f64738546c8869086110a26f98671095
+  languageName: node
+  linkType: hard
+
+"winston@npm:^3.14.2":
+  version: 3.17.0
+  resolution: "winston@npm:3.17.0"
+  dependencies:
+    "@colors/colors": "npm:^1.6.0"
+    "@dabh/diagnostics": "npm:^2.0.2"
+    async: "npm:^3.2.3"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.7.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.9.0"
+  checksum: 10c0/ec8eaeac9a72b2598aedbff50b7dac82ce374a400ed92e7e705d7274426b48edcb25507d78cff318187c4fb27d642a0e2a39c57b6badc9af8e09d4a40636a5f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add a Winston-backed logging module with scoped loggers and exported logging option types
- instrument Fastypest workflows, SQL execution, test setup hooks, and the pre-commit script with structured log output
- expose logging configuration in public options and replace raw console usage across the project

## Testing
- yarn build
- yarn eslint
- yarn test:ci *(fails: connect ECONNREFUSED 127.0.0.1:3306)*

------
https://chatgpt.com/codex/tasks/task_e_68d4745891f4832a9360aa98303d748b