### PR TITLE
Enable multi-level logging options and tests coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "url": "https://github.com/juanjoGonDev/fastypest/issues"
   },
   "homepage": "https://github.com/juanjoGonDev/fastypest#readme",
+  "dependencies": {
+    "winston": "^3.14.2"
+  },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@swc-node/jest": "^1.9.1",
@@ -57,6 +60,7 @@
     "@swc/helpers": "^0.5.17",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.5.1",
+    "@types/winston": "^2.4.4",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.44.1",
     "@typescript-eslint/types": "8.44.1",

--- a/scripts/logger.js
+++ b/scripts/logger.js
@@ -1,0 +1,146 @@
+const { addColors, createLogger, format, transports } = require("winston");
+
+const LOG_LEVELS = {
+  error: 0,
+  warn: 1,
+  notice: 2,
+  info: 3,
+  debug: 4,
+  verbose: 5,
+};
+
+const LOG_COLORS = {
+  error: "bold red",
+  warn: "bold yellow",
+  notice: "bold green",
+  info: "bold cyan",
+  debug: "bold magenta",
+  verbose: "bold blue",
+};
+
+const LOG_LEVEL_ICONS = {
+  error: "❌",
+  warn: "⚠️",
+  notice: "🟢",
+  info: "💡",
+  debug: "🧭",
+  verbose: "🌀",
+};
+
+const LOG_LEVEL_LABELS = {
+  error: "ERROR",
+  warn: "WARN",
+  notice: "LOG",
+  info: "INFO",
+  debug: "DEBUG",
+  verbose: "VERBOSE",
+};
+
+const LOG_TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
+const LOG_FIELD_LABEL = "label";
+const LOG_FIELD_MESSAGE = "message";
+const LOG_FIELD_LEVEL = "level";
+const LOG_FIELD_TIMESTAMP = "timestamp";
+const LOG_FIELD_DETAILS = "details";
+const DETAIL_SEPARATOR = " · ";
+const DETAIL_PREFIX = " — ";
+const DEFAULT_LEVEL = "notice";
+const DEFAULT_ENABLED = true;
+
+addColors(LOG_COLORS);
+
+const formatDetailValue = (detail) => {
+  if (detail === undefined) {
+    return undefined;
+  }
+  if (detail === null) {
+    return "null";
+  }
+  if (detail instanceof Date) {
+    return detail.toISOString();
+  }
+  if (detail instanceof Error) {
+    return detail.message;
+  }
+  if (typeof detail === "boolean") {
+    return detail ? "yes" : "no";
+  }
+  return String(detail);
+};
+
+const formatDetails = (details = []) => {
+  const formatted = details
+    .map((detail) => formatDetailValue(detail))
+    .filter((value) => Boolean(value && value.length > 0));
+  if (formatted.length === 0) {
+    return undefined;
+  }
+  return formatted.join(DETAIL_SEPARATOR);
+};
+
+const formatMessage = (info) => {
+  const label = info[LOG_FIELD_LABEL];
+  const level = info[LOG_FIELD_LEVEL];
+  const timestamp = info[LOG_FIELD_TIMESTAMP];
+  const levelLabel = LOG_LEVEL_LABELS[level] ?? String(level ?? "");
+  const levelIcon = LOG_LEVEL_ICONS[level] ? `${LOG_LEVEL_ICONS[level]} ` : "";
+  const detailsText = info[LOG_FIELD_DETAILS]
+    ? `${DETAIL_PREFIX}${String(info[LOG_FIELD_DETAILS])}`
+    : "";
+  const timestampText = timestamp ? `${timestamp} ` : "";
+  return `${timestampText}${levelIcon}[${label ?? ""}] ${levelLabel} ${info[LOG_FIELD_MESSAGE]}${detailsText}`;
+};
+
+const baseLogger = createLogger({
+  levels: LOG_LEVELS,
+  level: "verbose",
+  format: format.combine(
+    format.timestamp({ format: LOG_TIMESTAMP_FORMAT }),
+    format.colorize({ all: true }),
+    format.printf((info) => formatMessage(info))
+  ),
+  transports: [new transports.Console()],
+  silent: false,
+});
+
+const mergeOptions = (options = {}) => ({
+  enabled: options.enabled ?? DEFAULT_ENABLED,
+  level: options.level ?? DEFAULT_LEVEL,
+});
+
+const normalizeDetails = (details) => {
+  if (!details) {
+    return [];
+  }
+  return details.flatMap((entry) => (Array.isArray(entry) ? entry : [entry]));
+};
+
+const createScriptLogger = (scope, options = {}) => {
+  const configuration = mergeOptions(options);
+  const log = (level, message, details = []) => {
+    if (!configuration.enabled) {
+      return;
+    }
+    baseLogger.level = configuration.level;
+    const detailText = formatDetails(normalizeDetails(details));
+    const payload = {
+      level,
+      message,
+      [LOG_FIELD_LABEL]: scope,
+    };
+    if (detailText) {
+      payload[LOG_FIELD_DETAILS] = detailText;
+    }
+    baseLogger.log(payload);
+  };
+  return {
+    error: (message, ...details) => log("error", message, details),
+    warn: (message, ...details) => log("warn", message, details),
+    log: (message, ...details) => log("notice", message, details),
+    info: (message, ...details) => log("info", message, details),
+    debug: (message, ...details) => log("debug", message, details),
+    verbose: (message, ...details) => log("verbose", message, details),
+  };
+};
+
+module.exports = { createScriptLogger };

--- a/scripts/pre-commit.js
+++ b/scripts/pre-commit.js
@@ -1,5 +1,8 @@
 const fs = require("fs");
 const path = require("path");
+const { createScriptLogger } = require("./logger");
+
+const logger = createScriptLogger("pre-commit");
 
 const run = async (command, args = [], options = { stdio: "inherit" }) => {
   const { execa } = await import("execa");
@@ -7,8 +10,13 @@ const run = async (command, args = [], options = { stdio: "inherit" }) => {
     const { stdout } = await execa(command, args, options);
     return stdout;
   } catch (err) {
-    console.error(`✗ Error executing: ${command} ${args.join(" ")}`);
-    if (err.stderr) console.error(err.stderr);
+    const errorMessage = err.stderr || err.message || String(err);
+    logger.error(
+      "Command execution failed",
+      `Command ${command}`,
+      args.length > 0 ? `Arguments ${args.join(" ")}` : undefined,
+      errorMessage
+    );
     throw err;
   }
 };
@@ -19,40 +27,45 @@ const packagePath = path.join(testInstallDir, "package.tar.gz");
 const cleanUp = () => {
   if (fs.existsSync(testInstallDir)) {
     fs.rmSync(testInstallDir, { recursive: true, force: true });
-    console.log("🧹 Removed test-install directory.");
+    logger.log("Removed temporary test-install directory");
   }
 };
 
 (async () => {
+  logger.verbose("Starting pre-commit installation smoke test");
   try {
-    console.log("🛠 Building the package...");
+    logger.debug("Running yarn build for test verification");
     await run("yarn", ["build"]);
+    logger.info("Package build completed for smoke test");
 
     if (!fs.existsSync(testInstallDir)) {
       fs.mkdirSync(testInstallDir);
+      logger.log("Created test-install working directory", testInstallDir);
     }
 
-    console.log("📦 Packing the package...");
+    logger.debug("Packing the current workspace into a tarball");
     await run("yarn", ["pack", "--filename", packagePath]);
+    logger.info("Package tarball generated", packagePath);
 
-    console.log("📁 Initializing a fresh project in test-install...");
+    logger.debug("Initializing isolated project for installation test");
     await run("yarn", ["init", "-y"], { cwd: testInstallDir });
+    logger.info("Initialization completed inside test-install project");
 
     const yarnLockPath = path.join(testInstallDir, "yarn.lock");
     if (!fs.existsSync(yarnLockPath)) {
       fs.writeFileSync(yarnLockPath, "");
+      logger.log("Created placeholder yarn.lock inside test-install project");
     }
 
-    console.log("➕ Adding the tarball as a dev dependency...");
-    await run(
-      "yarn",
-      ["add", "-D", `fastypest@${packagePath}`],
-      { cwd: testInstallDir }
-    );
+    logger.debug("Adding packed tarball as a dev dependency");
+    await run("yarn", ["add", "-D", `fastypest@${packagePath}`], {
+      cwd: testInstallDir,
+    });
+    logger.log("Tarball installation succeeded inside the test project");
 
-    console.log("✅ Pre-commit install test succeeded!");
+    logger.info("Pre-commit smoke test finished successfully");
   } catch (error) {
-    console.error("❌ Pre-commit check failed:", error.message || error);
+    logger.error("Pre-commit smoke test failed", error.message || String(error));
     process.exitCode = 1;
   } finally {
     cleanUp();

--- a/src/core/fastypest.ts
+++ b/src/core/fastypest.ts
@@ -18,34 +18,66 @@ import {
   type IncrementDetail,
   type Manager,
 } from "./types";
+import {
+  configureLogging,
+  createScopedLogger,
+  LogLevel,
+  LOGGING_LEVEL_LABELS,
+  LOGGING_LEVEL_SEQUENCE,
+} from "../logging";
+import type { LoggingOptions, ScopedLogger } from "../logging";
+
+const PROGRESS_OFFSET = 1;
 
 export class Fastypest extends SQLScript {
   private manager: EntityManager;
   private tables: Set<string> = new Set();
   private tablesWithAutoIncrement: Map<string, IncrementDetail[]> = new Map();
   private restoreInOder: boolean = false;
-  private readonly options: Required<FastypestOptions>;
+  private readonly options: Required<Omit<FastypestOptions, "logging">>;
   private readonly changedTables: Set<string> = new Set();
+  private readonly logger: ScopedLogger;
 
   constructor(
     connection: DataSource | Connection,
     options?: FastypestOptions
   ) {
     super(connection.options.type);
+    const loggingConfiguration = this.resolveLoggingConfiguration(options?.logging);
+    const resolvedLogging = configureLogging(loggingConfiguration);
+    this.logger = createScopedLogger("Fastypest");
     this.manager = connection.manager;
     this.options = {
       changeDetectionStrategy:
         options?.changeDetectionStrategy ?? ChangeDetectionStrategy.None,
     };
+    const levelList =
+      resolvedLogging.levels && resolvedLogging.levels.length > 0
+        ? resolvedLogging.levels
+        : LOGGING_LEVEL_SEQUENCE;
+    const levelLabels = levelList.map((level) => LOGGING_LEVEL_LABELS[level]);
+    const loggingDetails = [
+      `Levels ${levelLabels.join(", ")}`,
+      `Database ${this.getType()}`,
+      `Change detection ${this.options.changeDetectionStrategy}`,
+    ];
+    if (resolvedLogging.enabled) {
+      this.logger.log("🟢 Logging enabled", ...loggingDetails);
+    } else {
+      this.logger.warn("⚪️ Logging disabled", ...loggingDetails);
+    }
     if (
       this.options.changeDetectionStrategy ===
       ChangeDetectionStrategy.Subscriber
     ) {
+      this.logger.info("🛰️ Change detection strategy enabled");
       this.registerSubscriber(connection);
     }
   }
 
   public async init(): Promise<void> {
+    const timer = this.logger.timer("Initialization");
+    this.logger.verbose("🚀 Initialization started", `Database ${this.getType()}`);
     await this.manager.transaction(async (em: EntityManager) => {
       await this.detectTables(em);
       await this.calculateDependencyTables(em);
@@ -55,16 +87,28 @@ export class Fastypest extends SQLScript {
         this.detectTablesWithAutoIncrement(em, tables),
       ]);
     });
+    timer.end(
+      "✅ Initialization completed",
+      LogLevel.Info,
+      `Tables ${this.tables.size}`,
+      `Tables with auto increment ${this.tablesWithAutoIncrement.size}`
+    );
   }
 
   private async createTempTable(
     em: EntityManager,
     tables: string[]
   ): Promise<void> {
+    const totalTables = tables.length;
     await Promise.all(
-      tables.map(async (tableName) => {
+      tables.map(async (tableName, index) => {
         await this.execQuery(em, "dropTempTable", { tableName });
         await this.execQuery(em, "createTempTable", { tableName });
+        this.logger.debug(
+          "🧪 Temporary table prepared",
+          `Table ${tableName}`,
+          `Progress ${index + PROGRESS_OFFSET}/${totalTables}`
+        );
       })
     );
   }
@@ -73,20 +117,27 @@ export class Fastypest extends SQLScript {
     em: EntityManager,
     tables: string[]
   ): Promise<void> {
-    for (const tableName of tables) {
-      await this.processTable(em, tableName);
+    const totalTables = tables.length;
+    for (const [index, tableName] of tables.entries()) {
+      await this.processTable(em, tableName, index + PROGRESS_OFFSET, totalTables);
     }
+    this.logger.debug(
+      "📊 Auto increment analysis completed",
+      `Tables with auto increment ${this.tablesWithAutoIncrement.size}`
+    );
   }
 
   private async processTable(
     em: EntityManager,
-    tableName: string
+    tableName: string,
+    position: number,
+    total: number
   ): Promise<void> {
     const columns = await this.getColumnsWithAutoIncrement(em, tableName);
     if (!columns) return;
 
     for (const column of columns) {
-      await this.processColumn(em, tableName, column);
+      await this.processColumn(em, tableName, column, position, total);
     }
   }
 
@@ -105,7 +156,9 @@ export class Fastypest extends SQLScript {
   private async processColumn(
     em: EntityManager,
     tableName: string,
-    column: ColumnsWithAutoIncrement
+    column: ColumnsWithAutoIncrement,
+    position: number,
+    total: number
   ): Promise<void> {
     const stat = await this.getMaxColumnIndex(
       em,
@@ -121,6 +174,13 @@ export class Fastypest extends SQLScript {
       sequenceName,
       index: String(index + (INDEX_OFFSET_CONFIG[this.getType()] ?? 0)),
     });
+    this.logger.debug(
+      "🔁 Auto increment column processed",
+      `Table ${tableName}`,
+      `Column ${column.column_name}`,
+      `Sequence ${sequenceName}`,
+      `Progress ${position}/${total}`
+    );
   }
 
   private async getMaxColumnIndex(
@@ -151,12 +211,33 @@ export class Fastypest extends SQLScript {
   }
 
   public async restoreData(): Promise<void> {
+    const tablesToRestore = this.getTablesForRestore();
+    if (this.shouldTrackChanges() && this.changedTables.size === 0) {
+      this.logger.debug(
+        "🕊️ No tracked table changes detected",
+        `Tables ${tablesToRestore.length}`
+      );
+    }
+    const timer = this.logger.timer("Restore process");
+    const changeSummary = this.shouldTrackChanges()
+      ? `Tracked changes ${this.changedTables.size}`
+      : undefined;
+    this.logger.verbose(
+      "🛠️ Restore process started",
+      `Tables selected ${tablesToRestore.length}`,
+      changeSummary
+    );
     await this.manager.transaction(async (em: EntityManager) => {
       const { foreignKey, restoreOrder } = await this.restoreManager(em);
       await foreignKey.disable();
       await restoreOrder();
       await foreignKey.enable();
     });
+    timer.end(
+      "🎉 Restore process completed",
+      LogLevel.Info,
+      `Tables restored ${tablesToRestore.length}`
+    );
   }
 
   protected async restoreManager(em: EntityManager): Promise<Manager> {
@@ -174,10 +255,20 @@ export class Fastypest extends SQLScript {
 
     const typesWithForeignKey: DBType[] = ["postgres", "mariadb", "mysql"];
     if (typesWithForeignKey.includes(this.getType())) {
-      manager.foreignKey.disable = async (): Promise<void> =>
-        this.execQuery(em, "foreignKey.disable");
-      manager.foreignKey.enable = async (): Promise<void> =>
-        this.execQuery(em, "foreignKey.enable");
+      manager.foreignKey.disable = async (): Promise<void> => {
+        this.logger.debug(
+          "🚧 Foreign keys disabled",
+          `Database ${this.getType()}`
+        );
+        await this.execQuery(em, "foreignKey.disable");
+      };
+      manager.foreignKey.enable = async (): Promise<void> => {
+        await this.execQuery(em, "foreignKey.enable");
+        this.logger.debug(
+          "🆗 Foreign keys enabled",
+          `Database ${this.getType()}`
+        );
+      };
     }
 
     manager.restoreOrder = (): Promise<void> => this.restoreOrder(em);
@@ -186,6 +277,8 @@ export class Fastypest extends SQLScript {
   }
 
   private async calculateDependencyTables(em: EntityManager): Promise<void> {
+    const timer = this.logger.timer("Dependency planning");
+    this.logger.debug("🧭 Calculating dependency order for restore");
     const dependencyTree = await this.execQuery<DependencyTreeQueryOut>(
       em,
       "dependencyTree"
@@ -193,6 +286,12 @@ export class Fastypest extends SQLScript {
 
     if (!dependencyTree.length) {
       this.restoreInOder = false;
+      timer.end(
+        "🧭 Dependency order calculated",
+        LogLevel.Debug,
+        "Mode parallel",
+        `Tables ${this.tables.size}`
+      );
       return;
     }
 
@@ -200,26 +299,61 @@ export class Fastypest extends SQLScript {
     this.tables.clear();
     this.tables = sortedTables;
     this.restoreInOder = true;
+    timer.end(
+      "🧭 Dependency order calculated",
+      LogLevel.Debug,
+      "Mode ordered",
+      `Tables ${this.tables.size}`
+    );
   }
 
   private async detectTables(em: EntityManager): Promise<void> {
+    const timer = this.logger.timer("Table discovery");
+    this.logger.debug("🗂️ Discovering tables from database");
     const tables = await this.execQuery<Table>(em, "getTables");
-    if (!tables) return;
+    if (!tables) {
+      timer.end(
+        "🗂️ Table discovery completed",
+        LogLevel.Debug,
+        `Tables ${this.tables.size}`
+      );
+      return;
+    }
 
     tables.forEach((row) => {
       this.tables.add(row.name);
     });
+    timer.end(
+      "🗂️ Table discovery completed",
+      LogLevel.Debug,
+      `Tables ${this.tables.size}`
+    );
   }
 
   private async restoreOrder(em: EntityManager): Promise<void> {
     const tables = this.getTablesForRestore();
+    const totalTables = tables.length;
     if (this.restoreInOder) {
-      for (const tableName of tables) {
-        await this.recreateData(em, tableName);
+      this.logger.verbose("🧱 Restore mode ordered", `Tables ${totalTables}`);
+      for (const [index, tableName] of tables.entries()) {
+        await this.recreateData(
+          em,
+          tableName,
+          index + PROGRESS_OFFSET,
+          totalTables
+        );
       }
     } else {
+      this.logger.verbose("🧱 Restore mode parallel", `Tables ${totalTables}`);
       await Promise.all(
-        tables.map((tableName) => this.recreateData(em, tableName))
+        tables.map((tableName, index) =>
+          this.recreateData(
+            em,
+            tableName,
+            index + PROGRESS_OFFSET,
+            totalTables
+          )
+        )
       );
     }
     if (this.shouldTrackChanges()) {
@@ -229,11 +363,37 @@ export class Fastypest extends SQLScript {
 
   private async recreateData(
     em: EntityManager,
-    tableName: string
+    tableName: string,
+    position: number,
+    total: number
   ): Promise<void> {
+    const timer = this.logger.timer(`Restore ${tableName}`);
+    this.logger.debug(
+      "📥 Restoring table",
+      `Table ${tableName}`,
+      `Progress ${position}/${total}`
+    );
     await this.execQuery(em, "truncateTable", { tableName });
+    timer.mark(
+      "🧹 Table truncated",
+      LogLevel.Debug,
+      `Table ${tableName}`,
+      `Progress ${position}/${total}`
+    );
     await this.execQuery(em, "restoreData", { tableName });
+    timer.mark(
+      "📦 Table data restored",
+      LogLevel.Debug,
+      `Table ${tableName}`,
+      `Progress ${position}/${total}`
+    );
     await this.resetAutoIncrementColumns(em, tableName);
+    timer.end(
+      "✅ Table restored",
+      LogLevel.Info,
+      `Table ${tableName}`,
+      `Progress ${position}/${total}`
+    );
   }
 
   private async resetAutoIncrementColumns(
@@ -250,6 +410,13 @@ export class Fastypest extends SQLScript {
         sequenceName,
         index,
       });
+      this.logger.debug(
+        "♻️ Auto increment column reset",
+        `Table ${tableName}`,
+        `Column ${column}`,
+        `Sequence ${sequenceName}`,
+        `Next value ${index}`
+      );
     }
   }
 
@@ -259,6 +426,10 @@ export class Fastypest extends SQLScript {
     });
     this.getSubscriberCollection(connection).push(subscriber);
     this.bindSubscriber(subscriber, connection);
+    this.logger.info(
+      "📡 Change tracking subscriber registered",
+      `Database ${this.getType()}`
+    );
   }
 
   private isDataSource(
@@ -307,6 +478,11 @@ export class Fastypest extends SQLScript {
     if (filtered.length === 0) {
       return tables;
     }
+    this.logger.debug(
+      "🗜️ Filtering tables by tracked changes",
+      `Matched tables ${filtered.length}`,
+      `Total tables ${tables.length}`
+    );
     return filtered;
   }
 
@@ -314,7 +490,30 @@ export class Fastypest extends SQLScript {
     if (!this.shouldTrackChanges()) {
       return;
     }
+    const wasTracked = this.changedTables.has(tableName);
     this.changedTables.add(tableName);
+    if (!wasTracked) {
+      this.logger.debug(
+        "🔎 Table change detected",
+        `Table ${tableName}`,
+        `Tracked tables ${this.changedTables.size}`
+      );
+    }
+  }
+
+  private resolveLoggingConfiguration(
+    logging?: boolean | LoggingOptions
+  ): LoggingOptions | undefined {
+    if (typeof logging === "boolean") {
+      return { enabled: logging };
+    }
+    if (!logging) {
+      return undefined;
+    }
+    if (logging.enabled === undefined) {
+      return { ...logging, enabled: true };
+    }
+    return logging;
   }
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,5 @@
 export * from "./fastypest";
 export { ChangeDetectionStrategy } from "./types";
 export type { FastypestOptions } from "./types";
+export { LogLevel } from "../logging";
+export type { LoggingOptions } from "../logging";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,4 +1,5 @@
 import { DataSourceOptions } from "typeorm";
+import type { LoggingOptions } from "../logging";
 
 export type Table = { name: string };
 export type DependencyTreeQueryOut = {
@@ -13,6 +14,7 @@ export enum ChangeDetectionStrategy {
 
 export type FastypestOptions = {
   changeDetectionStrategy?: ChangeDetectionStrategy;
+  logging?: boolean | LoggingOptions;
 };
 
 export type ColumnsWithAutoIncrement = {

--- a/src/logging/constants.ts
+++ b/src/logging/constants.ts
@@ -1,0 +1,66 @@
+export enum LogLevel {
+  Error = "error",
+  Warn = "warn",
+  Log = "notice",
+  Info = "info",
+  Debug = "debug",
+  Verbose = "verbose",
+}
+
+export const LOGGING_DEFAULT_ENABLED = false;
+export const LOGGING_TIMESTAMP_FORMAT = "YYYY-MM-DD HH:mm:ss";
+
+export const LOGGING_LEVEL_WEIGHTS: Record<LogLevel, number> = {
+  [LogLevel.Error]: 0,
+  [LogLevel.Warn]: 1,
+  [LogLevel.Log]: 2,
+  [LogLevel.Info]: 3,
+  [LogLevel.Debug]: 4,
+  [LogLevel.Verbose]: 5,
+};
+
+export const LOGGING_LEVEL_SEQUENCE: LogLevel[] = [
+  LogLevel.Error,
+  LogLevel.Warn,
+  LogLevel.Log,
+  LogLevel.Info,
+  LogLevel.Debug,
+  LogLevel.Verbose,
+];
+
+export const LOGGING_COLORS: Record<LogLevel, string> = {
+  [LogLevel.Error]: "bold red",
+  [LogLevel.Warn]: "bold yellow",
+  [LogLevel.Log]: "bold green",
+  [LogLevel.Info]: "bold cyan",
+  [LogLevel.Debug]: "bold magenta",
+  [LogLevel.Verbose]: "bold blue",
+};
+
+export const LOGGING_LEVEL_ICONS: Record<LogLevel, string> = {
+  [LogLevel.Error]: "❌",
+  [LogLevel.Warn]: "⚠️",
+  [LogLevel.Log]: "🟢",
+  [LogLevel.Info]: "💡",
+  [LogLevel.Debug]: "🧭",
+  [LogLevel.Verbose]: "🌀",
+};
+
+export const LOGGING_LEVEL_LABELS: Record<LogLevel, string> = {
+  [LogLevel.Error]: "ERROR",
+  [LogLevel.Warn]: "WARN",
+  [LogLevel.Log]: "LOG",
+  [LogLevel.Info]: "INFO",
+  [LogLevel.Debug]: "DEBUG",
+  [LogLevel.Verbose]: "VERBOSE",
+};
+
+export type LoggingOptions = {
+  enabled?: boolean;
+  levels?: LogLevel[];
+};
+
+export type ResolvedLoggingOptions = {
+  enabled: boolean;
+  levels?: LogLevel[];
+};

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,0 +1,14 @@
+export {
+  configureLogging,
+  createScopedLogger,
+  ScopedLogger,
+  getLoggingOptions,
+} from "./logger";
+export {
+  LogLevel,
+  LOGGING_DEFAULT_ENABLED,
+  LOGGING_LEVEL_LABELS,
+  LOGGING_LEVEL_SEQUENCE,
+  type LoggingOptions,
+  type ResolvedLoggingOptions,
+} from "./constants";

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -1,0 +1,358 @@
+import { performance } from "node:perf_hooks";
+import { addColors, createLogger, format, transports } from "winston";
+import {
+  LOGGING_COLORS,
+  LOGGING_DEFAULT_ENABLED,
+  LOGGING_LEVEL_ICONS,
+  LOGGING_LEVEL_LABELS,
+  LOGGING_LEVEL_WEIGHTS,
+  LOGGING_TIMESTAMP_FORMAT,
+  LogLevel,
+  type LoggingOptions,
+  type ResolvedLoggingOptions,
+} from "./constants";
+
+const LOG_FIELD_LABEL = "label";
+const LOG_FIELD_MESSAGE = "message";
+const LOG_FIELD_LEVEL = "level";
+const LOG_FIELD_TIMESTAMP = "timestamp";
+const LOG_FIELD_DETAILS = "details";
+const ANSI_ESCAPE_PATTERN = /\u001b\[[0-9;]*m/g;
+const DETAIL_SEPARATOR = " · ";
+const DETAIL_PREFIX = " — ";
+const MILLISECONDS_IN_SECOND = 1000;
+const SECONDS_IN_MINUTE = 60;
+const MINUTES_IN_HOUR = 60;
+const MILLISECONDS_IN_MINUTE = MILLISECONDS_IN_SECOND * SECONDS_IN_MINUTE;
+const MILLISECONDS_IN_HOUR = MILLISECONDS_IN_MINUTE * MINUTES_IN_HOUR;
+const DECIMAL_PRECISION_SHORT = 2;
+const DECIMAL_PRECISION_LONG = 1;
+const LOGGING_LEVELS_KEY: keyof LoggingOptions = "levels";
+
+const formatDetailValue = (detail: LogDetail): string | undefined => {
+  if (detail === undefined) {
+    return undefined;
+  }
+  if (detail === null) {
+    return "null";
+  }
+  if (detail instanceof Date) {
+    return detail.toISOString();
+  }
+  if (detail instanceof Error) {
+    return detail.message;
+  }
+  if (typeof detail === "boolean") {
+    return detail ? "yes" : "no";
+  }
+  return String(detail);
+};
+
+const trimDecimals = (value: number): string => {
+  if (Number.isInteger(value)) {
+    return value.toString();
+  }
+  return value.toString();
+};
+
+const formatSeconds = (seconds: number): string => {
+  const precision = seconds < 10 ? DECIMAL_PRECISION_SHORT : DECIMAL_PRECISION_LONG;
+  const rounded = Number(seconds.toFixed(precision));
+  return `${trimDecimals(rounded)}s`;
+};
+
+const formatDurationText = (durationMs: number): string => {
+  if (durationMs <= 0) {
+    return "0ms";
+  }
+  const segments: string[] = [];
+  const hours = Math.floor(durationMs / MILLISECONDS_IN_HOUR);
+  let remaining = durationMs - hours * MILLISECONDS_IN_HOUR;
+  const minutes = Math.floor(remaining / MILLISECONDS_IN_MINUTE);
+  remaining -= minutes * MILLISECONDS_IN_MINUTE;
+  const seconds = remaining / MILLISECONDS_IN_SECOND;
+  const wholeSeconds = Math.floor(seconds);
+  const leftoverMs = Math.round(remaining - wholeSeconds * MILLISECONDS_IN_SECOND);
+
+  if (hours > 0) {
+    segments.push(`${hours}h`);
+  }
+  if (minutes > 0) {
+    segments.push(`${minutes}m`);
+  }
+  if (hours > 0 || minutes > 0) {
+    if (wholeSeconds > 0) {
+      segments.push(`${wholeSeconds}s`);
+    }
+    if (segments.length === 0 || leftoverMs > 0) {
+      if (leftoverMs > 0) {
+        segments.push(`${leftoverMs}ms`);
+      }
+    }
+  } else if (seconds >= 1) {
+    segments.push(formatSeconds(seconds));
+  } else {
+    segments.push(`${Math.round(durationMs)}ms`);
+  }
+  return segments.join(" ");
+};
+
+type LogDetail = string | number | boolean | bigint | Date | Error | null | undefined;
+
+type LogDetailsInput = LogDetail | LogDetail[];
+
+type LoggerInfo = Record<string, unknown> & {
+  level: string;
+  message: string;
+  [LOG_FIELD_DETAILS]?: string;
+};
+
+type LoggerPayload = LoggerInfo & {
+  [LOG_FIELD_LABEL]: string;
+};
+
+type TimerEmitter = (level: LogLevel, message: string, details: LogDetail[]) => void;
+
+const extractLevel = (info: LoggerInfo): LogLevel | undefined => {
+  const levelText = (info[LOG_FIELD_LEVEL] as string | undefined) ?? info.level;
+  if (!levelText) {
+    return undefined;
+  }
+  const normalized = levelText.replace(ANSI_ESCAPE_PATTERN, "").toLowerCase();
+  return normalized in LOGGING_LEVEL_WEIGHTS ? (normalized as LogLevel) : undefined;
+};
+
+const formatDetails = (details: LogDetail[]): string | undefined => {
+  const formatted = details
+    .map((detail) => formatDetailValue(detail))
+    .filter((value): value is string => Boolean(value && value.length > 0));
+  if (formatted.length === 0) {
+    return undefined;
+  }
+  return formatted.join(DETAIL_SEPARATOR);
+};
+
+const formatLogMessage = (info: LoggerInfo): string => {
+  const label = info[LOG_FIELD_LABEL] as string | undefined;
+  const timestamp = info[LOG_FIELD_TIMESTAMP] as string | undefined;
+  const level = extractLevel(info);
+  const fallbackLevel = info.level.replace(ANSI_ESCAPE_PATTERN, "").toUpperCase();
+  const message = info[LOG_FIELD_MESSAGE] ? String(info[LOG_FIELD_MESSAGE]) : info.message;
+  const levelLabel = level ? LOGGING_LEVEL_LABELS[level] : fallbackLevel;
+  const levelIcon = level ? `${LOGGING_LEVEL_ICONS[level]} ` : "";
+  const detailText = info[LOG_FIELD_DETAILS] ? String(info[LOG_FIELD_DETAILS]) : "";
+  const formattedDetails = detailText ? `${DETAIL_PREFIX}${detailText}` : "";
+  const timestampText = timestamp ? `${timestamp} ` : "";
+  return `${timestampText}${levelIcon}[${label ?? ""}] ${levelLabel} ${message}${formattedDetails}`;
+};
+
+addColors(LOGGING_COLORS);
+
+const baseLogger = createLogger({
+  levels: LOGGING_LEVEL_WEIGHTS,
+  level: LogLevel.Verbose,
+  format: format.combine(
+    format.timestamp({ format: LOGGING_TIMESTAMP_FORMAT }),
+    format.colorize({ all: true }),
+    format.printf((info: unknown) => formatLogMessage(info as LoggerInfo))
+  ),
+  transports: [new transports.Console()],
+  silent: false,
+});
+
+let globalOptions: ResolvedLoggingOptions = {
+  enabled: LOGGING_DEFAULT_ENABLED,
+  levels: undefined,
+};
+
+const resolveEnabled = (enabled: boolean | undefined, hasOptions: boolean): boolean => {
+  if (enabled !== undefined) {
+    return enabled;
+  }
+  if (hasOptions) {
+    return true;
+  }
+  return LOGGING_DEFAULT_ENABLED;
+};
+
+const normalizeLevels = (levels?: LogLevel[]): LogLevel[] | undefined => {
+  if (!levels || levels.length === 0) {
+    return undefined;
+  }
+  const unique = Array.from(new Set(levels));
+  return unique.length > 0 ? unique : undefined;
+};
+
+const hasLevelsOption = (options?: LoggingOptions): boolean => {
+  if (!options) {
+    return false;
+  }
+  return Object.prototype.hasOwnProperty.call(options, LOGGING_LEVELS_KEY);
+};
+
+const resolveLoggingOptions = (options?: LoggingOptions): ResolvedLoggingOptions => {
+  const hasOptions = Boolean(options);
+  const enabled = resolveEnabled(options?.enabled, hasOptions);
+  if (!enabled) {
+    return { enabled, levels: undefined };
+  }
+  return {
+    enabled,
+    levels: normalizeLevels(options?.levels),
+  };
+};
+
+const shouldLog = (level: LogLevel, options: ResolvedLoggingOptions): boolean => {
+  if (!options.enabled) {
+    return false;
+  }
+  if (options.levels && options.levels.length > 0) {
+    return options.levels.includes(level);
+  }
+  return true;
+};
+
+const mergeOptions = (local?: LoggingOptions): ResolvedLoggingOptions => {
+  if (!local) {
+    return globalOptions;
+  }
+  const resolvedLocal = resolveLoggingOptions(local);
+  if (hasLevelsOption(local)) {
+    return resolvedLocal;
+  }
+  return {
+    enabled: resolvedLocal.enabled,
+    levels: globalOptions.levels,
+  };
+};
+
+const normalizeDetails = (input: LogDetailsInput[]): LogDetail[] => {
+  return input.flatMap((entry) => {
+    if (Array.isArray(entry)) {
+      return entry;
+    }
+    return [entry];
+  });
+};
+
+const logWithDetails = (
+  level: LogLevel,
+  scope: string,
+  message: string,
+  details: LogDetail[],
+  options: ResolvedLoggingOptions
+): void => {
+  if (!shouldLog(level, options)) {
+    return;
+  }
+  const formattedDetails = formatDetails(details);
+  const logPayload: LoggerPayload = {
+    level,
+    message,
+    [LOG_FIELD_LABEL]: scope,
+  };
+  if (formattedDetails) {
+    logPayload[LOG_FIELD_DETAILS] = formattedDetails;
+  }
+  baseLogger.log(logPayload);
+};
+
+export const configureLogging = (options?: LoggingOptions): ResolvedLoggingOptions => {
+  globalOptions = resolveLoggingOptions(options);
+  return globalOptions;
+};
+
+export class LoggerTimer {
+  private readonly start = performance.now();
+  private lastMark = this.start;
+  private finished = false;
+
+  constructor(
+    private readonly label: string,
+    private readonly emit: TimerEmitter
+  ) {}
+
+  public mark(message: string, level: LogLevel = LogLevel.Debug, ...details: LogDetailsInput[]): void {
+    if (this.finished) {
+      return;
+    }
+    const now = performance.now();
+    const totalElapsed = now - this.start;
+    const segmentElapsed = now - this.lastMark;
+    this.lastMark = now;
+    const timerDetails: LogDetail[] = [
+      `${this.label} total ${formatDurationText(totalElapsed)}`,
+    ];
+    if (segmentElapsed > 0 && segmentElapsed !== totalElapsed) {
+      timerDetails.push(`segment ${formatDurationText(segmentElapsed)}`);
+    }
+    const normalized = normalizeDetails(details);
+    this.emit(level, message, [...timerDetails, ...normalized]);
+  }
+
+  public end(
+    message?: string,
+    level: LogLevel = LogLevel.Info,
+    ...details: LogDetailsInput[]
+  ): void {
+    if (this.finished) {
+      return;
+    }
+    const totalElapsed = performance.now() - this.start;
+    const normalized = normalizeDetails(details);
+    const timerDetails: LogDetail[] = [`${this.label} total ${formatDurationText(totalElapsed)}`];
+    this.emit(level, message ?? `${this.label} completed`, [...timerDetails, ...normalized]);
+    this.finished = true;
+  }
+}
+
+export class ScopedLogger {
+  constructor(private readonly scope: string, private readonly localOptions?: LoggingOptions) {}
+
+  public error(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Error, message, details);
+  }
+
+  public warn(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Warn, message, details);
+  }
+
+  public log(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Log, message, details);
+  }
+
+  public info(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Info, message, details);
+  }
+
+  public debug(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Debug, message, details);
+  }
+
+  public verbose(message: string, ...details: LogDetailsInput[]): void {
+    this.write(LogLevel.Verbose, message, details);
+  }
+
+  public timer(label: string): LoggerTimer {
+    return new LoggerTimer(label, (level, message, details) => {
+      this.write(level, message, details);
+    });
+  }
+
+  public formatDuration(durationMs: number): string {
+    return formatDurationText(durationMs);
+  }
+
+  private write(level: LogLevel, message: string, details: LogDetailsInput[]): void {
+    const normalized = normalizeDetails(details);
+    logWithDetails(level, this.scope, message, normalized, mergeOptions(this.localOptions));
+  }
+}
+
+export const createScopedLogger = (scope: string, options?: LoggingOptions): ScopedLogger =>
+  new ScopedLogger(scope, options);
+
+export const getLoggingOptions = (): ResolvedLoggingOptions => ({
+  ...globalOptions,
+  levels: globalOptions.levels ? [...globalOptions.levels] : undefined,
+});

--- a/tests/__tests__/change-detection.spec.ts
+++ b/tests/__tests__/change-detection.spec.ts
@@ -2,6 +2,7 @@ import { DataSource } from "typeorm";
 import {
   ChangeDetectionStrategy,
   Fastypest,
+  LogLevel,
 } from "../../dist/core";
 import { getConnection } from "../config/orm.config";
 import { seedCount } from "../config/seed.config";
@@ -17,8 +18,10 @@ const DEFAULT_SIMPLE_ID = 1;
 
 describe("Change detection strategy", () => {
   const connection: DataSource = getConnection();
+  const testLogLevels = Object.values(LogLevel) as LogLevel[];
   const fastypest = new Fastypest(connection, {
     changeDetectionStrategy: ChangeDetectionStrategy.Subscriber,
+    logging: { enabled: true, levels: testLogLevels },
   });
   const basicRepository = connection.getRepository(Basic);
   const simpleRepository = connection.getRepository(Simple);

--- a/tests/config/global.setup.ts
+++ b/tests/config/global.setup.ts
@@ -1,16 +1,27 @@
+import { createScopedLogger, LogLevel } from "../../src/logging";
 import { seed } from "../seeds/seed";
 import { prepareDatabase } from "./orm.config";
 
+const testLogLevels = Object.values(LogLevel) as LogLevel[];
+
+const logger = createScopedLogger("GlobalSetup", {
+  enabled: true,
+  levels: testLogLevels,
+});
+
 const init = async () => {
-  console.log("\nInitializing database...");
+  logger.verbose("⚙️ Preparing database for test suite");
   const connection = await prepareDatabase();
-  console.log("Seeding database...");
-  const startTime = Date.now();
+  const timer = logger.timer("Database seeding");
+  logger.debug("🌱 Seeding database with fixtures");
   await seed(connection);
-  const endTime = Date.now();
-  const totalTime = (endTime - startTime) / 1000;
-  console.log(`Database seeded in ${totalTime} seconds`);
+  timer.end(
+    "✅ Database seeded",
+    LogLevel.Info,
+    "Seeding completed for global setup"
+  );
   await connection.destroy();
+  logger.log("🧹 Database connection closed after seeding");
 };
 
 export default init;

--- a/tests/config/jest.setup.ts
+++ b/tests/config/jest.setup.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { DataSource } from "typeorm";
 import { Fastypest } from "../../dist/core";
+import { createScopedLogger, LogLevel } from "../../src/logging";
 import { initialize } from "./orm.config";
 
 jest.setTimeout(100_000);
@@ -9,6 +10,11 @@ let fastypest: Fastypest;
 let connection: DataSource;
 
 const CHANGE_DETECTION_SPEC_BASENAME = "change-detection.spec.ts";
+const testLogLevels = Object.values(LogLevel) as LogLevel[];
+const logger = createScopedLogger("JestSetup", {
+  enabled: true,
+  levels: testLogLevels,
+});
 
 const shouldSkipDefaultFastypestSetup = (): boolean => {
   const testPath = expect.getState().testPath;
@@ -19,16 +25,18 @@ const shouldSkipDefaultFastypestSetup = (): boolean => {
 beforeAll(async () => {
   connection = await initialize();
   if (shouldSkipDefaultFastypestSetup()) {
-    console.log("Skipping default fastypest setup");
+    logger.warn("⏭️ Skipping default Fastypest setup");
     return;
   }
-  fastypest = new Fastypest(connection);
+  fastypest = new Fastypest(connection, {
+    logging: { enabled: true, levels: testLogLevels },
+  });
   await fastypest.init();
 });
 
 afterEach(async () => {
   if (shouldSkipDefaultFastypestSetup()) {
-    console.log("Skipping default fastypest restore");
+    logger.warn("⏭️ Skipping default Fastypest restore");
     return;
   }
   await fastypest.restoreData();

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,6 +617,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@colors/colors@npm:1.6.0, @colors/colors@npm:^1.6.0":
+  version: 1.6.0
+  resolution: "@colors/colors@npm:1.6.0"
+  checksum: 10c0/9328a0778a5b0db243af54455b79a69e3fb21122d6c15ef9e9fcc94881d8d17352d8b2b2590f9bdd46fac5c2d6c1636dcfc14358a20c70e22daf89e1a759b629
+  languageName: node
+  linkType: hard
+
+"@dabh/diagnostics@npm:^2.0.2":
+  version: 2.0.3
+  resolution: "@dabh/diagnostics@npm:2.0.3"
+  dependencies:
+    colorspace: "npm:1.1.x"
+    enabled: "npm:2.0.x"
+    kuler: "npm:^2.0.0"
+  checksum: 10c0/a5133df8492802465ed01f2f0a5784585241a1030c362d54a602ed1839816d6c93d71dde05cf2ddb4fd0796238c19774406bd62fa2564b637907b495f52425fe
+  languageName: node
+  linkType: hard
+
 "@emnapi/core@npm:^1.4.3":
   version: 1.4.3
   resolution: "@emnapi/core@npm:1.4.3"
@@ -2289,6 +2307,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/triple-beam@npm:^1.3.2":
+  version: 1.3.5
+  resolution: "@types/triple-beam@npm:1.3.5"
+  checksum: 10c0/d5d7f25da612f6d79266f4f1bb9c1ef8f1684e9f60abab251e1261170631062b656ba26ff22631f2760caeafd372abc41e64867cde27fba54fafb73a35b9056a
+  languageName: node
+  linkType: hard
+
+"@types/winston@npm:^2.4.4":
+  version: 2.4.4
+  resolution: "@types/winston@npm:2.4.4"
+  dependencies:
+    winston: "npm:*"
+  checksum: 10c0/8b967c089ba71773cca671b76aba931b2849afb3a6c03cbc5ef04d19e44092e0957573c730cdfbdda71eeb44984d3554e7edb88391c2a3c1aa36cafadc8f2b87
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -3166,6 +3200,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"async@npm:^3.2.3":
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.7":
   version: 1.0.7
   resolution: "available-typed-arrays@npm:1.0.7"
@@ -3659,7 +3700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-convert@npm:^1.9.0":
+"color-convert@npm:^1.9.0, color-convert@npm:^1.9.3":
   version: 1.9.3
   resolution: "color-convert@npm:1.9.3"
   dependencies:
@@ -3684,10 +3725,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:~1.1.4":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95
+  languageName: node
+  linkType: hard
+
+"color-string@npm:^1.6.0":
+  version: 1.9.1
+  resolution: "color-string@npm:1.9.1"
+  dependencies:
+    color-name: "npm:^1.0.0"
+    simple-swizzle: "npm:^0.2.2"
+  checksum: 10c0/b0bfd74c03b1f837f543898b512f5ea353f71630ccdd0d66f83028d1f0924a7d4272deb278b9aef376cacf1289b522ac3fb175e99895283645a2dc3a33af2404
+  languageName: node
+  linkType: hard
+
+"color@npm:^3.1.3":
+  version: 3.2.1
+  resolution: "color@npm:3.2.1"
+  dependencies:
+    color-convert: "npm:^1.9.3"
+    color-string: "npm:^1.6.0"
+  checksum: 10c0/39345d55825884c32a88b95127d417a2c24681d8b57069413596d9fcbb721459ef9d9ec24ce3e65527b5373ce171b73e38dbcd9c830a52a6487e7f37bf00e83c
   languageName: node
   linkType: hard
 
@@ -3695,6 +3756,16 @@ __metadata:
   version: 2.0.20
   resolution: "colorette@npm:2.0.20"
   checksum: 10c0/e94116ff33b0ff56f3b83b9ace895e5bf87c2a7a47b3401b8c3f3226e050d5ef76cf4072fb3325f9dc24d1698f9b730baf4e05eeaf861d74a1883073f4c98a40
+  languageName: node
+  linkType: hard
+
+"colorspace@npm:1.1.x":
+  version: 1.1.4
+  resolution: "colorspace@npm:1.1.4"
+  dependencies:
+    color: "npm:^3.1.3"
+    text-hex: "npm:1.0.x"
+  checksum: 10c0/af5f91ff7f8e146b96e439ac20ed79b197210193bde721b47380a75b21751d90fa56390c773bb67c0aedd34ff85091883a437ab56861c779bd507d639ba7e123
   languageName: node
   linkType: hard
 
@@ -4374,6 +4445,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10c0/af014e759a72064cf66e6e694a7fc6b0ed3d8db680427b021a89727689671cefe9d04151b2cad51dbaf85d5ba790d061cd167f1cf32eb7b281f6368b3c181639
+  languageName: node
+  linkType: hard
+
+"enabled@npm:2.0.x":
+  version: 2.0.0
+  resolution: "enabled@npm:2.0.0"
+  checksum: 10c0/3b2c2af9bc7f8b9e291610f2dde4a75cf6ee52a68f4dd585482fbdf9a55d65388940e024e56d40bb03e05ef6671f5f53021fa8b72a20e954d7066ec28166713f
   languageName: node
   linkType: hard
 
@@ -5167,6 +5245,7 @@ __metadata:
     "@swc/helpers": "npm:^0.5.17"
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^24.5.1"
+    "@types/winston": "npm:^2.4.4"
     "@typescript-eslint/eslint-plugin": "npm:^8.44.0"
     "@typescript-eslint/parser": "npm:^8.44.1"
     "@typescript-eslint/types": "npm:8.44.1"
@@ -5193,6 +5272,7 @@ __metadata:
     typeorm: "npm:^0.3.26"
     typescript: "npm:^5.9.2"
     typescript-eslint: "npm:^8.44.0"
+    winston: "npm:^3.14.2"
   peerDependencies:
     typeorm: ^0.3.26
   languageName: unknown
@@ -5216,6 +5296,13 @@ __metadata:
     picomatch:
       optional: true
   checksum: 10c0/45b559cff889934ebb8bc498351e5acba40750ada7e7d6bde197768d2fa67c149be8ae7f8ff34d03f4e1eb20f2764116e56440aaa2f6689e9a4aa7ef06acafe9
+  languageName: node
+  linkType: hard
+
+"fecha@npm:^4.2.0":
+  version: 4.2.3
+  resolution: "fecha@npm:4.2.3"
+  checksum: 10c0/0e895965959cf6a22bb7b00f0bf546f2783836310f510ddf63f463e1518d4c96dec61ab33fdfd8e79a71b4856a7c865478ce2ee8498d560fe125947703c9b1cf
   languageName: node
   linkType: hard
 
@@ -5344,6 +5431,13 @@ __metadata:
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
+  languageName: node
+  linkType: hard
+
+"fn.name@npm:1.x.x":
+  version: 1.1.0
+  resolution: "fn.name@npm:1.1.0"
+  checksum: 10c0/8ad62aa2d4f0b2a76d09dba36cfec61c540c13a0fd72e5d94164e430f987a7ce6a743112bbeb14877c810ef500d1f73d7f56e76d029d2e3413f20d79e3460a9a
   languageName: node
   linkType: hard
 
@@ -6191,6 +6285,13 @@ __metadata:
   version: 0.2.1
   resolution: "is-arrayish@npm:0.2.1"
   checksum: 10c0/e7fb686a739068bb70f860b39b67afc62acc62e36bb61c5f965768abce1873b379c563e61dd2adad96ebb7edf6651111b385e490cf508378959b0ed4cac4e729
+  languageName: node
+  linkType: hard
+
+"is-arrayish@npm:^0.3.1":
+  version: 0.3.4
+  resolution: "is-arrayish@npm:0.3.4"
+  checksum: 10c0/1fa672a2f0bedb74154440310f616c0b6e53a95cf0625522ae050f06626d1cabd1a3d8085c882dc45c61ad0e7df2529aff122810b3b4a552880bf170d6df94e0
   languageName: node
   linkType: hard
 
@@ -7403,6 +7504,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"kuler@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "kuler@npm:2.0.0"
+  checksum: 10c0/0a4e99d92ca373f8f74d1dc37931909c4d0d82aebc94cf2ba265771160fc12c8df34eaaac80805efbda367e2795cb1f1dd4c3d404b6b1cf38aec94035b503d2d
+  languageName: node
+  linkType: hard
+
 "lefthook-darwin-arm64@npm:1.13.2":
   version: 1.13.2
   resolution: "lefthook-darwin-arm64@npm:1.13.2"
@@ -7660,6 +7768,20 @@ __metadata:
     strip-ansi: "npm:^7.1.0"
     wrap-ansi: "npm:^9.0.0"
   checksum: 10c0/4b350c0a83d7753fea34dcac6cd797d1dc9603291565de009baa4aa91c0447eab0d3815a05c8ec9ac04fdfffb43c82adcdb03ec1fceafd8518e1a8c1cff4ff89
+  languageName: node
+  linkType: hard
+
+"logform@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "logform@npm:2.7.0"
+  dependencies:
+    "@colors/colors": "npm:1.6.0"
+    "@types/triple-beam": "npm:^1.3.2"
+    fecha: "npm:^4.2.0"
+    ms: "npm:^2.1.1"
+    safe-stable-stringify: "npm:^2.3.1"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/4789b4b37413c731d1835734cb799240d31b865afde6b7b3e06051d6a4127bfda9e88c99cfbf296d084a315ccbed2647796e6a56b66e725bcb268c586f57558f
   languageName: node
   linkType: hard
 
@@ -8312,6 +8434,15 @@ __metadata:
   dependencies:
     wrappy: "npm:1"
   checksum: 10c0/5d48aca287dfefabd756621c5dfce5c91a549a93e9fdb7b8246bc4c4790aa2ec17b34a260530474635147aeb631a2dcc8b32c613df0675f96041cbb8244517d0
+  languageName: node
+  linkType: hard
+
+"one-time@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-time@npm:1.0.0"
+  dependencies:
+    fn.name: "npm:1.x.x"
+  checksum: 10c0/6e4887b331edbb954f4e915831cbec0a7b9956c36f4feb5f6de98c448ac02ff881fd8d9b55a6b1b55030af184c6b648f340a76eb211812f4ad8c9b4b8692fdaa
   languageName: node
   linkType: hard
 
@@ -9096,7 +9227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2":
+"readable-stream@npm:3, readable-stream@npm:^3.0.0, readable-stream@npm:^3.0.2, readable-stream@npm:^3.4.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -9383,6 +9514,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"safe-stable-stringify@npm:^2.3.1":
+  version: 2.5.0
+  resolution: "safe-stable-stringify@npm:2.5.0"
+  checksum: 10c0/baea14971858cadd65df23894a40588ed791769db21bafb7fd7608397dbdce9c5aac60748abae9995e0fc37e15f2061980501e012cd48859740796bea2987f49
+  languageName: node
+  linkType: hard
+
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -9612,6 +9750,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-swizzle@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "simple-swizzle@npm:0.2.4"
+  dependencies:
+    is-arrayish: "npm:^0.3.1"
+  checksum: 10c0/846c3fdd1325318d5c71295cfbb99bfc9edc4c8dffdda5e6e9efe30482bbcd32cf360fc2806f46ac43ff7d09bcfaff20337bb79f826f0e6a8e366efd3cdd7868
+  languageName: node
+  linkType: hard
+
 "slash@npm:3.0.0, slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -9819,6 +9966,13 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/e5a1e23a4057a86a97971465418f22ea89bd439ac36ade88812dd920e4e61873e8abd6a9b72a03a67ef50faa00a2daf1ab745c5a15b46d03e0544a0296354227
+  languageName: node
+  linkType: hard
+
+"stack-trace@npm:0.0.x":
+  version: 0.0.10
+  resolution: "stack-trace@npm:0.0.10"
+  checksum: 10c0/9ff3dabfad4049b635a85456f927a075c9d0c210e3ea336412d18220b2a86cbb9b13ec46d6c37b70a302a4ea4d49e30e5d4944dd60ae784073f1cde778ac8f4b
   languageName: node
   linkType: hard
 
@@ -10208,6 +10362,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"text-hex@npm:1.0.x":
+  version: 1.0.0
+  resolution: "text-hex@npm:1.0.0"
+  checksum: 10c0/57d8d320d92c79d7c03ffb8339b825bb9637c2cbccf14304309f51d8950015c44464b6fd1b6820a3d4821241c68825634f09f5a2d9d501e84f7c6fd14376860d
+  languageName: node
+  linkType: hard
+
 "through2@npm:^2.0.0":
   version: 2.0.5
   resolution: "through2@npm:2.0.5"
@@ -10292,6 +10453,13 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: 10c0/03cfefde6c59ff57138412b8c6be922ecc5aec30694d784f2a65ef8dcbd47faef580b7de0c949345abdc56ec4b4abf64dd1e5aea619b200316e471a3dd5bf1f6
+  languageName: node
+  linkType: hard
+
+"triple-beam@npm:^1.3.0":
+  version: 1.4.1
+  resolution: "triple-beam@npm:1.4.1"
+  checksum: 10c0/4bf1db71e14fe3ff1c3adbe3c302f1fdb553b74d7591a37323a7badb32dc8e9c290738996cbb64f8b10dc5a3833645b5d8c26221aaaaa12e50d1251c9aba2fea
   languageName: node
   linkType: hard
 
@@ -10975,6 +11143,36 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/449fa5c44ed120ccecfe18c433296a4978a7583bf2391c50abce13f76878d2476defde04d0f79db8165bdf432853c1f8389d0485ca6e8ebce3bbcded513d5e6a
+  languageName: node
+  linkType: hard
+
+"winston-transport@npm:^4.9.0":
+  version: 4.9.0
+  resolution: "winston-transport@npm:4.9.0"
+  dependencies:
+    logform: "npm:^2.7.0"
+    readable-stream: "npm:^3.6.2"
+    triple-beam: "npm:^1.3.0"
+  checksum: 10c0/e2990a172e754dbf27e7823772214a22dc8312f7ec9cfba831e5ef30a5d5528792e5ea8f083c7387ccfc5b2af20e3691f64738546c8869086110a26f98671095
+  languageName: node
+  linkType: hard
+
+"winston@npm:*, winston@npm:^3.14.2":
+  version: 3.17.0
+  resolution: "winston@npm:3.17.0"
+  dependencies:
+    "@colors/colors": "npm:^1.6.0"
+    "@dabh/diagnostics": "npm:^2.0.2"
+    async: "npm:^3.2.3"
+    is-stream: "npm:^2.0.0"
+    logform: "npm:^2.7.0"
+    one-time: "npm:^1.0.0"
+    readable-stream: "npm:^3.4.0"
+    safe-stable-stringify: "npm:^2.3.1"
+    stack-trace: "npm:0.0.x"
+    triple-beam: "npm:^1.3.0"
+    winston-transport: "npm:^4.9.0"
+  checksum: 10c0/ec8eaeac9a72b2598aedbff50b7dac82ce374a400ed92e7e705d7274426b48edcb25507d78cff318187c4fb27d642a0e2a39c57b6badc9af8e09d4a40636a5f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- allow logging options to default to all levels when enabled and remove the single-level threshold control in favor of explicit level lists
- display enabled level lists in Fastypest startup messages when multiple levels are active
- configure the test harness to always enable all logging levels for scoped loggers and Fastypest instances

## Testing
- yarn build
- yarn eslint
- yarn test:ci *(fails: connect ECONNREFUSED 127.0.0.1:3306)*

------
https://chatgpt.com/codex/tasks/task_e_68d4745891f4832a9360aa98303d748b