### PR TITLE
Document logging options in READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -68,6 +68,28 @@ const fastypest = new Fastypest(connection, {
 - Si no se captura ningún evento del subscriber, Fastypest vuelve a restaurar toda la base de datos y garantiza que los cambios realizados únicamente con `connection.query()` se reviertan.
 - Los subscribers de TypeORM no se activan con `.query(...)`, por lo que al habilitar la estrategia del subscriber es necesario trabajar con repositorios o query builders para disfrutar del seguimiento automático.
 
+## 🔍 Registro
+
+Fastypest incluye un logger basado en Winston que facilita seguir el flujo de inicialización y restauración.
+
+- El registro está desactivado por defecto. Actívalo con `logging: true` o define una configuración personalizada.
+- Usa `LoggingDetailLevel` para alternar entre el modo simple (errores, avisos, notices e info) y el modo detallado (todos los niveles).
+- Combina `LoggingDetailLevel` con un array `levels` cuando necesites centrarte en niveles concretos de `LogLevel`.
+
+```typescript
+import { Fastypest, LogLevel, LoggingDetailLevel } from "fastypest";
+
+const fastypest = new Fastypest(connection, {
+  logging: {
+    enabled: true,
+    detail: LoggingDetailLevel.Detailed,
+    levels: [LogLevel.Info, LogLevel.Debug],
+  },
+});
+```
+
+Cuando defines `detail` y `levels` al mismo tiempo, Fastypest solo imprime la intersección de ambos filtros para mantener el registro enfocado en los eventos relevantes.
+
 ## ⚙️ Flujo de trabajo automatizado
 
 Este proyecto usa un sistema CI/CD avanzado con GitHub Actions:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,28 @@ const fastypest = new Fastypest(connection, {
 - When no subscriber event is captured Fastypest falls back to restoring the whole database, ensuring that changes executed exclusively through `connection.query()` are still reverted.
 - TypeORM subscribers are not triggered by raw queries, so enabling the subscriber strategy requires using repositories or query builders for automatic tracking.
 
+## 🔍 Logging
+
+Fastypest ships with a Winston-based logger that helps you trace the initialization and restore workflow.
+
+- Logging is disabled by default. Enable it with `logging: true` or provide a detailed configuration.
+- Use `LoggingDetailLevel` to toggle between the simple preset (errors, warnings, notices, info) and the detailed preset (all levels).
+- Combine `LoggingDetailLevel` with an explicit `levels` array when you need to focus on specific `LogLevel` entries.
+
+```typescript
+import { Fastypest, LogLevel, LoggingDetailLevel } from "fastypest";
+
+const fastypest = new Fastypest(connection, {
+  logging: {
+    enabled: true,
+    detail: LoggingDetailLevel.Detailed,
+    levels: [LogLevel.Info, LogLevel.Debug],
+  },
+});
+```
+
+When both `detail` and `levels` are provided, Fastypest only prints the intersection of the two filters, keeping the output focused on the events you care about.
+
 ## ⚙️ Automated Workflow
 
 This project leverages a sophisticated CI/CD setup using GitHub Actions:


### PR DESCRIPTION
## Summary
- document the new logging configuration options in the English README
- add the same logging guidance to the Spanish README