### PR TITLE
Bump version to v3.0.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.0.33](https://github.com/juanjoGonDev/fastypest/compare/v3.0.32...v3.0.33) (2026-07-01)
+
 ### [3.0.32](https://github.com/juanjoGonDev/fastypest/compare/v3.0.31...v3.0.32) (2026-06-29)
 
 ### [3.0.31](https://github.com/juanjoGonDev/fastypest/compare/v3.0.30...v3.0.31) (2026-06-24)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastypest",
-  "version": "3.0.32",
+  "version": "3.0.33",
   "description": "Restores the database automatically after each test. Allows serial execution of tests without having to delete and restore the database having to stop the application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version to v3.0.33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **3.0.33**.
  * Updated the changelog with the new release entry and compare link for **v3.0.32...v3.0.33**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->