### PR TITLE
Bump version to v3.0.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.0.35](https://github.com/juanjoGonDev/fastypest/compare/v3.0.34...v3.0.35) (2026-07-09)
+
 ### [3.0.34](https://github.com/juanjoGonDev/fastypest/compare/v3.0.33...v3.0.34) (2026-07-07)
 
 ### [3.0.33](https://github.com/juanjoGonDev/fastypest/compare/v3.0.32...v3.0.33) (2026-07-01)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastypest",
-  "version": "3.0.34",
+  "version": "3.0.35",
   "description": "Restores the database automatically after each test. Allows serial execution of tests without having to delete and restore the database having to stop the application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version to v3.0.35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to **3.0.35**.
  * Added a new changelog entry for **3.0.35** with the release date and comparison link from the previous version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->