### PR TITLE
Bump version to v3.0.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.0.37](https://github.com/juanjoGonDev/fastypest/compare/v3.0.36...v3.0.37) (2026-07-17)
+
 ### [3.0.36](https://github.com/juanjoGonDev/fastypest/compare/v3.0.35...v3.0.36) (2026-07-14)
 
 ### [3.0.35](https://github.com/juanjoGonDev/fastypest/compare/v3.0.34...v3.0.35) (2026-07-09)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastypest",
-  "version": "3.0.36",
+  "version": "3.0.37",
   "description": "Restores the database automatically after each test. Allows serial execution of tests without having to delete and restore the database having to stop the application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps version to v3.0.37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release notes for version 3.0.37, dated July 17, 2026.
  * Added a comparison link to the previous release.

* **Chores**
  * Updated the package version to 3.0.37.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->