### PR TITLE
refactor(release): split event-driven delivery

### DIFF
--- a/.agents/specs/2026-07-31-event-driven-release-pipeline.md
+++ b/.agents/specs/2026-07-31-event-driven-release-pipeline.md
@@ -19,7 +19,8 @@ Only `fastypest` is in scope. `typeorm-test-db` and DevBar are excluded.
 - A personal access token or GitHub App token can create the release branch and pull request while allowing normal pull-request checks to run.
 - The `release.published` event supports both manually and automatically published GitHub Releases.
 - npm trusted publishing binds the package to an exact workflow filename and requires OIDC.
-- The current implementation combines npm publication, tag creation, and GitHub Release creation after a pull-request state transition.
+- The previous implementation combined npm publication, tag creation, and GitHub Release creation after a pull-request state transition.
+- Review found and the implementation corrected exact-release-commit targeting, shell template expansion, persisted checkout credentials, label validation under `pipefail`, and missing approval-workflow ownership documentation.
 
 ## Scope
 
@@ -52,13 +53,16 @@ release.published
 
 - A default-branch push below the threshold does not create a release pull request.
 - A default-branch push at or above the threshold creates at most one owner-authored `release/v<version>` pull request.
+- Release preparation is attached to the exact default-branch event SHA and does not drift to a newer branch head.
 - The generated pull request changes exactly `package.json` and `CHANGELOG.md`.
-- The trusted workflow validates the current head, title, branch, author, repository, base, label, package name/version, and changed files before approving.
-- The approval body remains `Approved by the trusted release workflow contract.`
+- The trusted workflow validates the current head, title, exact branch, author, repository, base, label, package name, monotonic version, changelog entry, destination tag/release state, and changed files before approving.
+- The approval is submitted through the reviews API against the validated commit SHA with body `Approved by the trusted release workflow contract.`
 - Auto-merge is enabled only for the validated current head and repository rules remain the merge authority.
 - A release pull-request merge does not immediately create another version pull request while the new package version lacks its GitHub Release.
-- A changed package version creates an immutable tag and GitHub Release targeting the exact default-branch commit.
-- Existing wrong-target tags fail without force-updating or deleting them.
+- The release baseline tag must target a commit whose `package.json` contains the current version and whose release metadata matches stable or prerelease state.
+- A changed package version creates an immutable tag and GitHub Release targeting the exact first-parent commit that introduced that version, including multi-commit push cases.
+- Existing releases are accepted as idempotent only when tag target, draft state, and prerelease state match the resolved contract.
+- Existing wrong-target tags or releases fail without force-updating or deleting them.
 - Generated GitHub Releases use `PAT_FINE`, so `release.published` can trigger the npm workflow.
 - Manually published owner releases trigger the same npm workflow.
 - npm publication validates package name, semantic version, tag, prerelease state, default-branch ancestry, build, package archive, and existing npm state.
@@ -75,6 +79,7 @@ release.published
 - Release creation can partially complete after tag creation.
 - Manual releases could target an untrusted commit or mismatched package version.
 - A prerelease could accidentally replace npm `latest`.
+- A multi-commit default-branch push could place commits after the version change and accidentally expand the release target.
 
 ## Controls
 
@@ -82,34 +87,43 @@ release.published
 - Keep PAT-backed jobs behind the `admin` environment and verify the authenticated actor is the repository owner.
 - Never checkout or execute pull-request code in the privileged approval job.
 - Serialize release preparation and GitHub Release creation with repository-scoped concurrency.
+- Attach release preparation to the event SHA before creating the release commit and branch.
 - Treat an open trusted release pull request as a preparation barrier.
 - Treat a package version without a GitHub Release as a preparation barrier.
 - Bind approval and auto-merge to the live head SHA.
-- Validate exact changed files and package metadata through the GitHub API.
-- Reject tag collisions and verify tag targets after creation.
+- Validate exact changed files, monotonic versioning, changelog content, and package metadata through the GitHub API.
+- Resolve the exact first-parent commit that introduced the package version.
+- Reject tag/release collisions and verify tag targets and release metadata after creation.
 - Require release tags to be reachable from the default branch before npm publication.
+- Pass event and action values into shell blocks through explicit environment variables.
 - Use npm OIDC without a token fallback.
 
 ## Tests
 
-- Parse every changed workflow as YAML.
-- Check each changed shell block with `bash -n` after neutralizing GitHub expressions.
-- Assert every third-party action reference is pinned to a full commit SHA.
-- Assert the preparation workflow contains no check polling, direct merge, npm publish, GitHub Release creation, force push, or destructive cleanup.
-- Assert the release creator uses a package-version-change gate, exact tag target validation, generated notes, and `PAT_FINE`.
-- Assert the npm publisher is triggered only by `release.published`, retains its filename, has `id-token: write`, and contains no npm token fallback.
-- Assert the trusted approval validates branch, title, package metadata, changed files, and current head before bot approval and PAT-backed auto-merge.
-- Run the repository pull-request workflow on the implementation branch.
-- Inspect CodeQL and review feedback before delivery.
+- Parsed every changed workflow as YAML.
+- Checked every changed shell block with `bash -n` after neutralizing GitHub expressions.
+- Checked every changed `actions/github-script` program by parsing it inside an async function wrapper.
+- Asserted every third-party action reference is pinned to a full commit SHA.
+- Asserted the preparation workflow contains no check polling, direct merge, npm publish, GitHub Release creation, force push, or destructive cleanup.
+- Asserted the release creator uses a package-version-change gate, exact tag target validation, generated notes, and `PAT_FINE`.
+- Asserted the npm publisher is triggered only by `release.published`, retains its filename, has `id-token: write`, and contains no npm token fallback.
+- Asserted the trusted approval validates branch, title, monotonic package metadata, changelog, changed files, destination collisions, and current head before bot approval and PAT-backed auto-merge.
+- Exercised the exact release-SHA resolver with synthetic histories covering a multi-commit push, manual recovery, and a later `package.json` edit that retained the same version.
+- Exercised the strict semantic-version parser and comparator for patch, minor, major, prerelease, stable-versus-prerelease, numeric-versus-string identifiers, and invalid leading-zero identifiers.
+- Ran the repository pull-request build, format, package-install smoke, and database matrix on implementation heads.
+- Resolved all initial review findings and confirmed no unresolved review threads before final delivery validation.
 
 ## Checks
 
-- YAML syntax.
-- Shell syntax.
-- Static workflow contract assertions.
-- Pull-request build, format, package smoke, and database matrix.
-- CodeQL and repository review checks.
-- Final diff inspection for secret exposure, mutable tags, privileged execution of PR code, and duplicate release ownership.
+- YAML syntax: passed.
+- Shell syntax: passed.
+- GitHub-script syntax: passed.
+- Static workflow contract assertions: passed.
+- Exact release-SHA synthetic cases: passed.
+- Semantic-version parser/comparator cases: passed.
+- Pull-request build, format, package smoke, and database matrix: passed on hardened implementation heads; the final documentation head remains subject to the normal pull-request CI gate.
+- Initial review findings: resolved.
+- Final diff inspection: no secret values, mutable release tags, privileged execution of pull-request code, duplicate release ownership, or destructive failure cleanup found.
 
 ## Rollback
 
@@ -118,10 +132,10 @@ Revert the implementation pull request. Existing tags, releases, packages, and g
 ## Delivery
 
 - Branch: `agent/refactor-event-driven-release`
-- Pull request: pending
+- Pull request: `https://github.com/juanjoGonDev/fastypest/pull/1681`
 - Merge: requires explicit owner approval
 - Release/publication: not permitted from this implementation branch
 
 ## Status
 
-Implementation in progress.
+Implementation, review hardening, and static validation are complete. Delivery remains gated by pull-request CI and explicit owner merge approval; no merge, GitHub Release, tag, or npm publication has been performed.

--- a/.agents/specs/2026-07-31-event-driven-release-pipeline.md
+++ b/.agents/specs/2026-07-31-event-driven-release-pipeline.md
@@ -1,0 +1,127 @@
+# Event-driven release pipeline
+
+## Request
+
+Split Fastypest release automation into independent event-driven workflows:
+
+1. After each update to the default branch, count commits since the latest published release and create a version pull request once the configured threshold is reached.
+2. After a default-branch update changes `package.json` version, create the corresponding immutable tag and GitHub Release with generated notes.
+3. After a GitHub Release is published, publish the matching package version to npm through the existing trusted-publisher workflow.
+4. Automatically validate, approve, and queue trusted release pull requests for squash auto-merge.
+5. Preserve the exact `.github/workflows/auto-release.workflow.yml` filename required by npm OIDC.
+
+Only `fastypest` is in scope. `typeorm-test-db` and DevBar are excluded.
+
+## Evidence
+
+- GitHub suppresses most follow-up workflow runs for events emitted with the repository `GITHUB_TOKEN`.
+- Pull requests created with `GITHUB_TOKEN` require explicit workflow approval before their pull-request workflows run.
+- A personal access token or GitHub App token can create the release branch and pull request while allowing normal pull-request checks to run.
+- The `release.published` event supports both manually and automatically published GitHub Releases.
+- npm trusted publishing binds the package to an exact workflow filename and requires OIDC.
+- The current implementation combines npm publication, tag creation, and GitHub Release creation after a pull-request state transition.
+
+## Scope
+
+- Refactor `prepare-release.workflow.yml` to run on default-branch pushes and manual dispatch.
+- Add `create-github-release.workflow.yml`.
+- Change `auto-release.workflow.yml` to publish npm only from `release.published`.
+- Harden the existing trusted release approval job.
+- Add scoped GitHub automation guidance.
+- Preserve manual release recovery, manual release-to-npm delivery, dry-run release calculation, release strategies, breaking-change notes, build checks, and package installation smoke tests.
+
+## Decision
+
+Use event boundaries as the orchestration contract:
+
+```text
+push default branch
+  ├─ prepare release PR when threshold is reached
+  └─ create GitHub Release when package.json version changes
+
+release pull request
+  └─ validate exact contract → bot approval → PAT-backed auto-merge
+
+release.published
+  └─ validate tag and package → build/package smoke → npm OIDC publish
+```
+
+`PAT_FINE` is used only in the protected `admin` environment where an operation must emit a follow-up event: release branch push, release pull-request creation, auto-merge enablement, immutable tag creation, and GitHub Release publication. GitHub Actions bot approval continues to use `github.token`. npm publication uses OIDC only.
+
+## Acceptance
+
+- A default-branch push below the threshold does not create a release pull request.
+- A default-branch push at or above the threshold creates at most one owner-authored `release/v<version>` pull request.
+- The generated pull request changes exactly `package.json` and `CHANGELOG.md`.
+- The trusted workflow validates the current head, title, branch, author, repository, base, label, package name/version, and changed files before approving.
+- The approval body remains `Approved by the trusted release workflow contract.`
+- Auto-merge is enabled only for the validated current head and repository rules remain the merge authority.
+- A release pull-request merge does not immediately create another version pull request while the new package version lacks its GitHub Release.
+- A changed package version creates an immutable tag and GitHub Release targeting the exact default-branch commit.
+- Existing wrong-target tags fail without force-updating or deleting them.
+- Generated GitHub Releases use `PAT_FINE`, so `release.published` can trigger the npm workflow.
+- Manually published owner releases trigger the same npm workflow.
+- npm publication validates package name, semantic version, tag, prerelease state, default-branch ancestry, build, package archive, and existing npm state.
+- Stable versions publish to `latest`; prereleases publish to `next`.
+- Reruns are idempotent.
+- No workflow polls check runs, directly merges a pull request, force-pushes a tag, or deletes release evidence on failure.
+- The npm trusted-publisher workflow filename remains unchanged.
+
+## Risks
+
+- A broad or leaked PAT could create repository objects outside the intended release flow.
+- A privileged `pull_request_target` workflow could execute untrusted pull-request code.
+- Concurrent default-branch pushes could create duplicate release pull requests.
+- Release creation can partially complete after tag creation.
+- Manual releases could target an untrusted commit or mismatched package version.
+- A prerelease could accidentally replace npm `latest`.
+
+## Controls
+
+- Restrict `PAT_FINE` to this repository and the minimum Contents/Pull requests permissions.
+- Keep PAT-backed jobs behind the `admin` environment and verify the authenticated actor is the repository owner.
+- Never checkout or execute pull-request code in the privileged approval job.
+- Serialize release preparation and GitHub Release creation with repository-scoped concurrency.
+- Treat an open trusted release pull request as a preparation barrier.
+- Treat a package version without a GitHub Release as a preparation barrier.
+- Bind approval and auto-merge to the live head SHA.
+- Validate exact changed files and package metadata through the GitHub API.
+- Reject tag collisions and verify tag targets after creation.
+- Require release tags to be reachable from the default branch before npm publication.
+- Use npm OIDC without a token fallback.
+
+## Tests
+
+- Parse every changed workflow as YAML.
+- Check each changed shell block with `bash -n` after neutralizing GitHub expressions.
+- Assert every third-party action reference is pinned to a full commit SHA.
+- Assert the preparation workflow contains no check polling, direct merge, npm publish, GitHub Release creation, force push, or destructive cleanup.
+- Assert the release creator uses a package-version-change gate, exact tag target validation, generated notes, and `PAT_FINE`.
+- Assert the npm publisher is triggered only by `release.published`, retains its filename, has `id-token: write`, and contains no npm token fallback.
+- Assert the trusted approval validates branch, title, package metadata, changed files, and current head before bot approval and PAT-backed auto-merge.
+- Run the repository pull-request workflow on the implementation branch.
+- Inspect CodeQL and review feedback before delivery.
+
+## Checks
+
+- YAML syntax.
+- Shell syntax.
+- Static workflow contract assertions.
+- Pull-request build, format, package smoke, and database matrix.
+- CodeQL and repository review checks.
+- Final diff inspection for secret exposure, mutable tags, privileged execution of PR code, and duplicate release ownership.
+
+## Rollback
+
+Revert the implementation pull request. Existing tags, releases, packages, and generated release branches are not deleted. The previous merged-pull-request publication workflow is restored by the revert.
+
+## Delivery
+
+- Branch: `agent/refactor-event-driven-release`
+- Pull request: pending
+- Merge: requires explicit owner approval
+- Release/publication: not permitted from this implementation branch
+
+## Status
+
+Implementation in progress.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,64 @@
+# GitHub Automation Rules
+
+## Scope
+
+These rules apply to files under `.github/`.
+
+## Release pipeline ownership
+
+Release automation is split into three single-purpose workflows:
+
+- `prepare-release.workflow.yml` detects the commit threshold and creates a version pull request.
+- `create-github-release.workflow.yml` reacts to a changed `package.json` version on the default branch and creates the immutable tag and GitHub Release.
+- `auto-release.workflow.yml` is the npm trusted-publisher workflow. Its filename is part of the npm OIDC trust configuration and must not be renamed.
+
+Do not merge these responsibilities back into one workflow. GitHub branch requirements remain the source of truth for merging release pull requests.
+
+## Authentication boundaries
+
+- Use the default `github.token` for read operations, GitHub Actions bot approvals, and bot-authored review messages.
+- Use `secrets.PAT_FINE` only inside the protected `admin` environment for transitions that must emit follow-up repository events:
+  - pushing the generated release branch;
+  - creating the generated release pull request;
+  - enabling auto-merge after bot approval;
+  - creating the immutable release tag and GitHub Release.
+- Validate that `PAT_FINE` authenticates as the repository owner before using it.
+- Never expose `PAT_FINE` to `pull_request` jobs or execute pull-request code in a privileged `pull_request_target` job.
+- npm publication must use OIDC with `id-token: write`; do not add an npm write token fallback.
+
+## Trusted release pull requests
+
+A release pull request is eligible for automatic approval only when all of these conditions hold:
+
+- same repository;
+- repository-owner author;
+- default-branch base;
+- exact `release/v<package-version>` head branch;
+- `auto-release` label;
+- title `Bump version to v<package-version>`;
+- package name `fastypest`;
+- exactly `package.json` and `CHANGELOG.md` changed;
+- validation and approval bound to the current head SHA.
+
+The approval body is:
+
+`Approved by the trusted release workflow contract.`
+
+Auto-merge must use squash merge and an exact head-SHA match. Do not enumerate or poll check runs; repository rules decide when the merge is allowed.
+
+## Release integrity
+
+- Never force-update release tags.
+- Reject existing tags that point to another commit.
+- The automated GitHub Release must target the exact default-branch commit that changed `package.json`.
+- The npm publisher must verify the release tag matches `package.json`, the tag is reachable from the default branch, and the package version is not already published.
+- Stable versions publish to npm `latest`; prereleases publish to `next`.
+- Reruns must be idempotent and must not delete branches, tags, releases, or diagnostic evidence on failure.
+
+## Workflow security
+
+- Default to `permissions: read-all`; elevate per job only.
+- Pin third-party actions to full commit SHAs.
+- Use `persist-credentials: false` unless a documented operation requires otherwise.
+- Keep privileged jobs behind the `admin` environment.
+- Do not use untrusted event fields in shell commands without passing them through explicit environment variables and validating their format.

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -6,11 +6,12 @@ These rules apply to files under `.github/`.
 
 ## Release pipeline ownership
 
-Release automation is split into three single-purpose workflows:
+Release delivery is split into three single-purpose workflows, with trusted pull-request approval kept in its existing automation owner:
 
 - `prepare-release.workflow.yml` detects the commit threshold and creates a version pull request.
 - `create-github-release.workflow.yml` reacts to a changed `package.json` version on the default branch and creates the immutable tag and GitHub Release.
 - `auto-release.workflow.yml` is the npm trusted-publisher workflow. Its filename is part of the npm OIDC trust configuration and must not be renamed.
+- `dependabot-auto-merge.workflow.yml` owns the `approve-release` job that validates, approves, and queues trusted release pull requests.
 
 Do not merge these responsibilities back into one workflow. GitHub branch requirements remain the source of truth for merging release pull requests.
 

--- a/.github/workflows/auto-release.workflow.yml
+++ b/.github/workflows/auto-release.workflow.yml
@@ -153,6 +153,8 @@ jobs:
           PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
           PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
           NPM_TAG: ${{ steps.release.outputs.npm_tag }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          ALREADY_PUBLISHED: ${{ steps.npm.outputs.published }}
         run: |
           set -euo pipefail
           for attempt in $(seq 1 12); do
@@ -167,7 +169,7 @@ jobs:
             sleep 5
           done
 
-          if [[ "${{ steps.npm.outputs.published }}" != "true" ]]; then
+          if [[ "$ALREADY_PUBLISHED" != "true" ]]; then
             dist_tag_version=$(npm view "${PACKAGE_NAME}" "dist-tags.${NPM_TAG}" --json | jq -r .)
             if [[ "$dist_tag_version" != "$PACKAGE_VERSION" ]]; then
               echo "::error title=npm dist-tag mismatch::$NPM_TAG points to $dist_tag_version instead of $PACKAGE_VERSION."
@@ -179,5 +181,5 @@ jobs:
             echo "### npm package published"
             echo "- Package: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
             echo "- Dist-tag: $NPM_TAG"
-            echo "- Source tag: ${{ github.event.release.tag_name }}"
+            echo "- Source tag: $RELEASE_TAG"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/auto-release.workflow.yml
+++ b/.github/workflows/auto-release.workflow.yml
@@ -1,91 +1,95 @@
 name: 🔄 Auto release
 
 on:
-  pull_request:
+  release:
     types:
-      - closed
+      - published
 
 permissions: read-all
 
 concurrency:
-  group: publish-release-${{ github.event.pull_request.number }}
+  group: npm-publish-${{ github.repository }}-${{ github.event.release.tag_name }}
   cancel-in-progress: false
 
 env:
   NODE_VERSION: "22.14.0"
+  EXPECTED_PACKAGE_NAME: fastypest
 
 jobs:
   publish:
+    name: Publish trusted GitHub Release to npm
     if: >-
       github.event.repository.fork == false &&
-      github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'auto-release') &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch &&
-      github.event.pull_request.user.login == github.repository_owner &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
-    name: Publish trusted merged release
+      github.event.release.draft == false &&
+      github.event.release.author.login == github.repository_owner
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: admin
     permissions:
-      contents: write
+      contents: read
       id-token: write
-      pull-requests: read
     steps:
-      - name: 🔐 Validate merged release contract
-        id: contract
+      - name: 📥 Checkout published release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 🔐 Validate published release contract
+        id: release
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_PRERELEASE: ${{ github.event.release.prerelease }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          pull_json=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
-          merged=$(jq -r .merged <<<"$pull_json")
-          head_sha=$(jq -r .head.sha <<<"$pull_json")
-          merge_sha=$(jq -r .merge_commit_sha <<<"$pull_json")
-          head_repo=$(jq -r .head.repo.full_name <<<"$pull_json")
-          head_ref=$(jq -r .head.ref <<<"$pull_json")
-          base_ref=$(jq -r .base.ref <<<"$pull_json")
-          author=$(jq -r .user.login <<<"$pull_json")
-          auto_release_label=$(jq -r '[.labels[].name] | index("auto-release") != null' <<<"$pull_json")
+          package_name=$(node -p "require('./package.json').name")
+          package_version=$(node -p "require('./package.json').version")
+          expected_tag="v${package_version}"
 
-          [[ "$merged" == "true" ]]
-          [[ "$head_sha" == "$EVENT_HEAD_SHA" ]]
-          [[ "$merge_sha" == "$EVENT_MERGE_SHA" ]]
-          [[ "$head_repo" == "$GITHUB_REPOSITORY" ]]
-          [[ "$head_ref" == release/* ]]
-          [[ "$base_ref" == "$DEFAULT_BRANCH" ]]
-          [[ "$author" == "$GITHUB_REPOSITORY_OWNER" ]]
-          [[ "$auto_release_label" == "true" ]]
-
-          mapfile -t changed_files < <(
-            gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename' | sort
-          )
-          expected_files=("CHANGELOG.md" "package.json")
-          if [[ "${changed_files[*]}" != "${expected_files[*]}" ]]; then
-            echo "::error title=Unexpected release files::Expected CHANGELOG.md and package.json, received: ${changed_files[*]}"
+          if [[ "$package_name" != "$EXPECTED_PACKAGE_NAME" ]]; then
+            echo "::error title=Unexpected package::Expected $EXPECTED_PACKAGE_NAME, received $package_name."
+            exit 1
+          fi
+          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+            echo "::error title=Release version mismatch::Release tag $RELEASE_TAG does not match package.json version $package_version."
+            exit 1
+          fi
+          if ! [[ "$package_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid package version::$package_version is not a supported semantic version."
             exit 1
           fi
 
-          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+          expected_prerelease=false
+          npm_tag=latest
+          if [[ "$package_version" == *-* ]]; then
+            expected_prerelease=true
+            npm_tag=next
+          fi
+          if [[ "$EVENT_PRERELEASE" != "$expected_prerelease" ]]; then
+            echo "::error title=Prerelease mismatch::GitHub Release prerelease=$EVENT_PRERELEASE but package version is $package_version."
+            exit 1
+          fi
 
-      - name: 📥 Checkout merged commit
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          ref: ${{ steps.contract.outputs.merge_sha }}
-          fetch-depth: 0
-          token: ${{ secrets.PAT_FINE }}
+          git fetch --force origin "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          release_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+          if ! git merge-base --is-ancestor "$release_sha" "refs/remotes/origin/$DEFAULT_BRANCH"; then
+            echo "::error title=Untrusted release commit::$RELEASE_TAG is not reachable from $DEFAULT_BRANCH."
+            exit 1
+          fi
+
+          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
+          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "npm_tag=$npm_tag" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
 
       - name: 🟢 Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.1.0
         with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: "https://registry.npmjs.org/"
-          cache: yarn
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org/
 
       - name: ⬆️ Update npm CLI
         run: npm install --global npm@11.5.1
@@ -94,65 +98,24 @@ jobs:
         run: yarn install --immutable --check-cache
 
       - name: 🚧 Build package
-        run: yarn run build
+        run: yarn build
 
-      - name: 🧪 Verify package archive
+      - name: 🧪 Verify package archive and installation
         run: |
           set -euo pipefail
           package_dir=$(mktemp -d)
           yarn pack --filename "$package_dir/package.tar.gz"
           tar -tzf "$package_dir/package.tar.gz" >/dev/null
-
-      - name: 🏷️ Validate release metadata
-        id: metadata
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          MERGE_SHA: ${{ steps.contract.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          package_name=$(node -p "require('./package.json').name")
-          package_version=$(node -p "require('./package.json').version")
-          release_tag="v${package_version}"
-          expected_title="Bump version to ${release_tag}"
-
-          if [[ "$PR_TITLE" != "$expected_title" ]]; then
-            echo "::error title=Release title mismatch::Expected '$expected_title', received '$PR_TITLE'."
-            exit 1
-          fi
-          if ! grep -Fq "[${package_version}]" CHANGELOG.md; then
-            echo "::error title=Missing changelog release::CHANGELOG.md does not contain ${package_version}."
-            exit 1
-          fi
-
-          echo "package_name=$package_name" >> "$GITHUB_OUTPUT"
-          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "merge_sha=$MERGE_SHA" >> "$GITHUB_OUTPUT"
-
-      - name: 🔒 Validate release tag state
-        id: tag_state
-        env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          MERGE_SHA: ${{ steps.metadata.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          git fetch --tags --force
-          if git rev-parse --verify "${RELEASE_TAG}^{commit}" >/dev/null 2>&1; then
-            existing_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-            if [[ "$existing_sha" != "$MERGE_SHA" ]]; then
-              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $MERGE_SHA."
-              exit 1
-            fi
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "exists=false" >> "$GITHUB_OUTPUT"
+          cd "$package_dir"
+          yarn init -y
+          touch yarn.lock
+          yarn add -D ./package.tar.gz
 
       - name: 🔎 Check npm publication state
-        id: npm_state
+        id: npm
         env:
-          PACKAGE_NAME: ${{ steps.metadata.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.metadata.outputs.package_version }}
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
         run: |
           set -euo pipefail
           error_file=$(mktemp)
@@ -179,50 +142,23 @@ jobs:
           cat "$error_file"
           exit "$status"
 
-      - name: 🎉 Publish to npm
-        if: steps.npm_state.outputs.published != 'true'
-        run: npm publish
-
-      - name: 🏷️ Create immutable release tag
-        if: steps.tag_state.outputs.exists != 'true'
+      - name: 🎉 Publish package with npm OIDC
+        if: steps.npm.outputs.published != 'true'
         env:
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          MERGE_SHA: ${{ steps.metadata.outputs.merge_sha }}
+          NPM_TAG: ${{ steps.release.outputs.npm_tag }}
+        run: npm publish --tag "$NPM_TAG"
+
+      - name: ✅ Verify npm publication
+        env:
+          PACKAGE_NAME: ${{ steps.release.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.release.outputs.package_version }}
+          NPM_TAG: ${{ steps.release.outputs.npm_tag }}
         run: |
           set -euo pipefail
-          git tag "$RELEASE_TAG" "$MERGE_SHA"
-          git push origin "refs/tags/${RELEASE_TAG}"
-
-      - name: 📦 Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            echo "GitHub Release $RELEASE_TAG already exists."
-            exit 0
-          fi
-          gh release create "$RELEASE_TAG" \
-            --verify-tag \
-            --title "Release ${RELEASE_TAG}" \
-            --notes "Automated release ${RELEASE_TAG}."
-
-      - name: ✅ Verify published release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PACKAGE_NAME: ${{ steps.metadata.outputs.package_name }}
-          PACKAGE_VERSION: ${{ steps.metadata.outputs.package_version }}
-          RELEASE_TAG: ${{ steps.metadata.outputs.release_tag }}
-          MERGE_SHA: ${{ steps.metadata.outputs.merge_sha }}
-        run: |
-          set -euo pipefail
-          published_version=
           for attempt in $(seq 1 12); do
-            if published_version=$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json | jq -r .); then
-              if [[ "$published_version" == "$PACKAGE_VERSION" ]]; then
-                break
-              fi
+            published_version=$(npm view "${PACKAGE_NAME}@${PACKAGE_VERSION}" version --json 2>/dev/null | jq -r . || true)
+            if [[ "$published_version" == "$PACKAGE_VERSION" ]]; then
+              break
             fi
             if (( attempt == 12 )); then
               echo "::error title=npm verification failed::${PACKAGE_NAME}@${PACKAGE_VERSION} was not visible after 12 attempts."
@@ -230,6 +166,18 @@ jobs:
             fi
             sleep 5
           done
-          gh release view "$RELEASE_TAG" >/dev/null
-          tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-          [[ "$tag_sha" == "$MERGE_SHA" ]]
+
+          if [[ "${{ steps.npm.outputs.published }}" != "true" ]]; then
+            dist_tag_version=$(npm view "${PACKAGE_NAME}" "dist-tags.${NPM_TAG}" --json | jq -r .)
+            if [[ "$dist_tag_version" != "$PACKAGE_VERSION" ]]; then
+              echo "::error title=npm dist-tag mismatch::$NPM_TAG points to $dist_tag_version instead of $PACKAGE_VERSION."
+              exit 1
+            fi
+          fi
+
+          {
+            echo "### npm package published"
+            echo "- Package: ${PACKAGE_NAME}@${PACKAGE_VERSION}"
+            echo "- Dist-tag: $NPM_TAG"
+            echo "- Source tag: ${{ github.event.release.tag_name }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-github-release.workflow.yml
+++ b/.github/workflows/create-github-release.workflow.yml
@@ -1,0 +1,188 @@
+name: 🏷️ Create GitHub release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact package.json version to recover as a GitHub Release
+        required: true
+        type: string
+
+permissions: read-all
+
+concurrency:
+  group: create-github-release-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create immutable GitHub Release
+    if: >-
+      github.event.repository.fork == false &&
+      github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: admin
+    permissions:
+      contents: read
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: 📥 Checkout release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: 🧭 Resolve changed package version
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          REQUESTED_VERSION: ${{ inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          current_version=$(node -p "require('./package.json').version")
+          if ! [[ "$current_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error title=Invalid package version::$current_version is not a supported semantic version."
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            requested_version="${REQUESTED_VERSION#v}"
+            if [[ "$requested_version" != "$current_version" ]]; then
+              echo "::error title=Version mismatch::Requested $requested_version but package.json contains $current_version."
+              exit 1
+            fi
+          else
+            zero_sha=0000000000000000000000000000000000000000
+            previous_version=
+            if [[ -n "$BEFORE_SHA" && "$BEFORE_SHA" != "$zero_sha" ]]; then
+              previous_version=$(git show "${BEFORE_SHA}:package.json" 2>/dev/null \
+                | node -e "let value=''; process.stdin.on('data', chunk => value += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(value).version));" \
+                2>/dev/null || true)
+            fi
+            if [[ -z "$previous_version" || "$previous_version" == "$current_version" ]]; then
+              echo "create=false" >> "$GITHUB_OUTPUT"
+              echo "package.json version did not change on this push."
+              exit 0
+            fi
+          fi
+
+          release_tag="v${current_version}"
+          if gh release view "$release_tag" --json tagName >/dev/null 2>&1; then
+            echo "create=false" >> "$GITHUB_OUTPUT"
+            echo "GitHub Release $release_tag already exists."
+            exit 0
+          fi
+
+          if git rev-parse --verify "${release_tag}^{commit}" >/dev/null 2>&1; then
+            existing_sha=$(git rev-list -n 1 "$release_tag")
+            if [[ "$existing_sha" != "$GITHUB_SHA" ]]; then
+              echo "::error title=Release tag collision::$release_tag points to $existing_sha instead of $GITHUB_SHA."
+              exit 1
+            fi
+          fi
+
+          prerelease=false
+          if [[ "$current_version" == *-* ]]; then
+            prerelease=true
+          fi
+
+          echo "create=true" >> "$GITHUB_OUTPUT"
+          echo "version=$current_version" >> "$GITHUB_OUTPUT"
+          echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+
+      - name: 🔐 Validate release publisher identity
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing release secret::Configure PAT_FINE in the admin environment."
+            exit 1
+          fi
+          actor_username=$(gh api user --jq .login)
+          if [[ "$actor_username" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid release actor::PAT_FINE authenticates as $actor_username instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+      - name: 🏷️ Create immutable release tag
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+            existing_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+            if [[ "$existing_sha" != "$GITHUB_SHA" ]]; then
+              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $GITHUB_SHA."
+              exit 1
+            fi
+            echo "Tag $RELEASE_TAG already points to the release commit."
+            exit 0
+          fi
+
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${RELEASE_TAG}" \
+            -f sha="$GITHUB_SHA" >/dev/null
+
+      - name: 📦 Publish GitHub Release
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.candidate.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "GitHub Release $RELEASE_TAG already exists."
+            exit 0
+          fi
+
+          release_args=(
+            "$RELEASE_TAG"
+            --verify-tag
+            --target "$GITHUB_SHA"
+            --title "Release $RELEASE_TAG"
+            --generate-notes
+          )
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            release_args+=(--prerelease)
+          fi
+          gh release create "${release_args[@]}"
+
+      - name: ✅ Verify GitHub Release
+        if: steps.candidate.outputs.create == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.candidate.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          release_json=$(gh release view "$RELEASE_TAG" --json tagName,isDraft,isPrerelease,url)
+          [[ "$(jq -r .tagName <<<"$release_json")" == "$RELEASE_TAG" ]]
+          [[ "$(jq -r .isDraft <<<"$release_json")" == "false" ]]
+          [[ "$(jq -r .isPrerelease <<<"$release_json")" == "$IS_PRERELEASE" ]]
+
+          git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
+          [[ "$tag_sha" == "$GITHUB_SHA" ]]
+
+          release_url=$(jq -r .url <<<"$release_json")
+          {
+            echo "### GitHub Release created"
+            echo "- Release: $release_url"
+            echo "- Tag: $RELEASE_TAG"
+            echo "- Commit: $GITHUB_SHA"
+            echo "- npm delivery: release.published event"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/create-github-release.workflow.yml
+++ b/.github/workflows/create-github-release.workflow.yml
@@ -108,9 +108,26 @@ jobs:
           fi
 
           release_tag="v${current_version}"
-          if gh release view "$release_tag" --json tagName >/dev/null 2>&1; then
+          prerelease=false
+          if [[ "$current_version" == *-* ]]; then
+            prerelease=true
+          fi
+
+          if existing_release_json=$(gh release view "$release_tag" --json tagName,isDraft,isPrerelease 2>/dev/null); then
+            git fetch --force origin "refs/tags/${release_tag}:refs/tags/${release_tag}"
+            existing_sha=$(git rev-list -n 1 "$release_tag")
+            existing_draft=$(jq -r .isDraft <<<"$existing_release_json")
+            existing_prerelease=$(jq -r .isPrerelease <<<"$existing_release_json")
+            if [[ "$existing_sha" != "$release_sha" ]]; then
+              echo "::error title=Release target mismatch::$release_tag points to $existing_sha instead of $release_sha."
+              exit 1
+            fi
+            if [[ "$existing_draft" != "false" || "$existing_prerelease" != "$prerelease" ]]; then
+              echo "::error title=Release metadata mismatch::$release_tag has draft=$existing_draft and prerelease=$existing_prerelease."
+              exit 1
+            fi
             echo "create=false" >> "$GITHUB_OUTPUT"
-            echo "GitHub Release $release_tag already exists."
+            echo "GitHub Release $release_tag already exists with the expected target and metadata."
             exit 0
           fi
 
@@ -120,11 +137,6 @@ jobs:
               echo "::error title=Release tag collision::$release_tag points to $existing_sha instead of $release_sha."
               exit 1
             fi
-          fi
-
-          prerelease=false
-          if [[ "$current_version" == *-* ]]; then
-            prerelease=true
           fi
 
           echo "create=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-github-release.workflow.yml
+++ b/.github/workflows/create-github-release.workflow.yml
@@ -46,6 +46,13 @@ jobs:
           REQUESTED_VERSION: ${{ inputs.version || '' }}
         run: |
           set -euo pipefail
+
+          read_package_version() {
+            git show "$1:package.json" 2>/dev/null \
+              | node -e "let value=''; process.stdin.on('data', chunk => value += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(value).version));" \
+              2>/dev/null || true
+          }
+
           current_version=$(node -p "require('./package.json').version")
           if ! [[ "$current_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error title=Invalid package version::$current_version is not a supported semantic version."
@@ -58,19 +65,46 @@ jobs:
               echo "::error title=Version mismatch::Requested $requested_version but package.json contains $current_version."
               exit 1
             fi
+            release_range="$GITHUB_SHA"
           else
             zero_sha=0000000000000000000000000000000000000000
             previous_version=
             if [[ -n "$BEFORE_SHA" && "$BEFORE_SHA" != "$zero_sha" ]]; then
-              previous_version=$(git show "${BEFORE_SHA}:package.json" 2>/dev/null \
-                | node -e "let value=''; process.stdin.on('data', chunk => value += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(value).version));" \
-                2>/dev/null || true)
+              previous_version=$(read_package_version "$BEFORE_SHA")
             fi
             if [[ -z "$previous_version" || "$previous_version" == "$current_version" ]]; then
               echo "create=false" >> "$GITHUB_OUTPUT"
               echo "package.json version did not change on this push."
               exit 0
             fi
+            release_range="${BEFORE_SHA}..${GITHUB_SHA}"
+          fi
+
+          release_sha=
+          while IFS= read -r candidate_sha; do
+            candidate_version=$(read_package_version "$candidate_sha")
+            if [[ "$candidate_version" != "$current_version" ]]; then
+              continue
+            fi
+
+            parent_sha=$(git rev-parse "${candidate_sha}^1" 2>/dev/null || true)
+            parent_version=
+            if [[ -n "$parent_sha" ]]; then
+              parent_version=$(read_package_version "$parent_sha")
+            fi
+            if [[ "$parent_version" != "$current_version" ]]; then
+              release_sha="$candidate_sha"
+              break
+            fi
+          done < <(git rev-list --first-parent "$release_range" -- package.json)
+
+          if [[ -z "$release_sha" ]]; then
+            echo "::error title=Unresolved release commit::No default-branch commit introduced package version $current_version."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$release_sha" "$GITHUB_SHA"; then
+            echo "::error title=Invalid release commit::$release_sha is not an ancestor of $GITHUB_SHA."
+            exit 1
           fi
 
           release_tag="v${current_version}"
@@ -82,8 +116,8 @@ jobs:
 
           if git rev-parse --verify "${release_tag}^{commit}" >/dev/null 2>&1; then
             existing_sha=$(git rev-list -n 1 "$release_tag")
-            if [[ "$existing_sha" != "$GITHUB_SHA" ]]; then
-              echo "::error title=Release tag collision::$release_tag points to $existing_sha instead of $GITHUB_SHA."
+            if [[ "$existing_sha" != "$release_sha" ]]; then
+              echo "::error title=Release tag collision::$release_tag points to $existing_sha instead of $release_sha."
               exit 1
             fi
           fi
@@ -97,6 +131,7 @@ jobs:
           echo "version=$current_version" >> "$GITHUB_OUTPUT"
           echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$release_sha" >> "$GITHUB_OUTPUT"
 
       - name: 🔐 Validate release publisher identity
         if: steps.candidate.outputs.create == 'true'
@@ -119,13 +154,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
           RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
         run: |
           set -euo pipefail
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
             git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
             existing_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-            if [[ "$existing_sha" != "$GITHUB_SHA" ]]; then
-              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $GITHUB_SHA."
+            if [[ "$existing_sha" != "$RELEASE_SHA" ]]; then
+              echo "::error title=Release tag collision::$RELEASE_TAG points to $existing_sha instead of $RELEASE_SHA."
               exit 1
             fi
             echo "Tag $RELEASE_TAG already points to the release commit."
@@ -134,7 +170,7 @@ jobs:
 
           gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
             -f ref="refs/tags/${RELEASE_TAG}" \
-            -f sha="$GITHUB_SHA" >/dev/null
+            -f sha="$RELEASE_SHA" >/dev/null
 
       - name: 📦 Publish GitHub Release
         if: steps.candidate.outputs.create == 'true'
@@ -142,6 +178,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
           RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
           IS_PRERELEASE: ${{ steps.candidate.outputs.prerelease }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
         run: |
           set -euo pipefail
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
@@ -152,7 +189,7 @@ jobs:
           release_args=(
             "$RELEASE_TAG"
             --verify-tag
-            --target "$GITHUB_SHA"
+            --target "$RELEASE_SHA"
             --title "Release $RELEASE_TAG"
             --generate-notes
           )
@@ -167,6 +204,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
           RELEASE_TAG: ${{ steps.candidate.outputs.tag }}
           IS_PRERELEASE: ${{ steps.candidate.outputs.prerelease }}
+          RELEASE_SHA: ${{ steps.candidate.outputs.release_sha }}
         run: |
           set -euo pipefail
           release_json=$(gh release view "$RELEASE_TAG" --json tagName,isDraft,isPrerelease,url)
@@ -176,13 +214,13 @@ jobs:
 
           git fetch --force origin "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
           tag_sha=$(git rev-list -n 1 "$RELEASE_TAG")
-          [[ "$tag_sha" == "$GITHUB_SHA" ]]
+          [[ "$tag_sha" == "$RELEASE_SHA" ]]
 
           release_url=$(jq -r .url <<<"$release_json")
           {
             echo "### GitHub Release created"
             echo "- Release: $release_url"
             echo "- Tag: $RELEASE_TAG"
-            echo "- Commit: $GITHUB_SHA"
+            echo "- Commit: $RELEASE_SHA"
             echo "- npm delivery: release.published event"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -47,6 +47,52 @@ jobs:
             const eventHeadSha = context.payload.pull_request.head.sha;
             const repositoryOwner = context.payload.repository.owner.login;
             const defaultBranch = context.payload.repository.default_branch;
+            const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?$/;
+
+            const parseSemver = (value) => {
+              const match = semverPattern.exec(value);
+              if (!match) return null;
+              return {
+                core: [Number(match[1]), Number(match[2]), Number(match[3])],
+                prerelease: match[4]?.split('.') ?? [],
+              };
+            };
+
+            const compareSemver = (left, right) => {
+              for (let index = 0; index < left.core.length; index += 1) {
+                if (left.core[index] !== right.core[index]) {
+                  return left.core[index] > right.core[index] ? 1 : -1;
+                }
+              }
+              if (left.prerelease.length === 0 || right.prerelease.length === 0) {
+                if (left.prerelease.length === right.prerelease.length) return 0;
+                return left.prerelease.length === 0 ? 1 : -1;
+              }
+              const length = Math.max(left.prerelease.length, right.prerelease.length);
+              for (let index = 0; index < length; index += 1) {
+                const leftIdentifier = left.prerelease[index];
+                const rightIdentifier = right.prerelease[index];
+                if (leftIdentifier === undefined) return -1;
+                if (rightIdentifier === undefined) return 1;
+                if (leftIdentifier === rightIdentifier) continue;
+                const leftNumeric = /^\d+$/.test(leftIdentifier);
+                const rightNumeric = /^\d+$/.test(rightIdentifier);
+                if (leftNumeric && rightNumeric) {
+                  return Number(leftIdentifier) > Number(rightIdentifier) ? 1 : -1;
+                }
+                if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+                return leftIdentifier > rightIdentifier ? 1 : -1;
+              }
+              return 0;
+            };
+
+            const readRepositoryFile = async (path, ref) => {
+              const response = await github.rest.repos.getContent({ owner, repo, path, ref });
+              if (Array.isArray(response.data) || response.data.type !== 'file') {
+                throw new Error(`${path} did not resolve to a repository file at ${ref}.`);
+              }
+              return Buffer.from(response.data.content, 'base64').toString('utf8');
+            };
 
             const { data: pullRequest } = await github.rest.pulls.get({
               owner,
@@ -62,15 +108,18 @@ jobs:
               return;
             }
 
-            const titleMatch = /^Bump version to v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?)$/.exec(
-              pullRequest.title,
-            );
-            if (!titleMatch) {
+            const titlePrefix = 'Bump version to v';
+            if (!pullRequest.title.startsWith(titlePrefix)) {
               core.setFailed(`Unexpected release pull request title: ${pullRequest.title}`);
               return;
             }
+            const version = pullRequest.title.slice(titlePrefix.length);
+            const parsedVersion = parseSemver(version);
+            if (!parsedVersion || pullRequest.title !== `${titlePrefix}${version}`) {
+              core.setFailed(`Invalid release version in title: ${pullRequest.title}`);
+              return;
+            }
 
-            const version = titleMatch[1];
             const expectedBranch = `release/v${version}`;
             const labels = pullRequest.labels.map((label) =>
               typeof label === 'string' ? label : label.name,
@@ -105,25 +154,45 @@ jobs:
               return;
             }
 
-            const packageResponse = await github.rest.repos.getContent({
-              owner,
-              repo,
-              path: 'package.json',
-              ref: pullRequest.head.sha,
-            });
-            if (Array.isArray(packageResponse.data) || packageResponse.data.type !== 'file') {
-              core.setFailed('package.json did not resolve to a repository file.');
+            const packageJson = JSON.parse(
+              await readRepositoryFile('package.json', pullRequest.head.sha),
+            );
+            const basePackageJson = JSON.parse(
+              await readRepositoryFile('package.json', pullRequest.base.sha),
+            );
+            const parsedBaseVersion = parseSemver(basePackageJson.version);
+            if (
+              packageJson.name !== 'fastypest' ||
+              basePackageJson.name !== 'fastypest' ||
+              packageJson.version !== version ||
+              !parsedBaseVersion ||
+              compareSemver(parsedVersion, parsedBaseVersion) <= 0
+            ) {
+              core.setFailed(
+                `Expected a monotonic fastypest version bump from ${basePackageJson.version} to ${version}.`,
+              );
               return;
             }
 
-            const packageJson = JSON.parse(
-              Buffer.from(packageResponse.data.content, 'base64').toString('utf8'),
-            );
-            if (packageJson.version !== version || packageJson.name !== 'fastypest') {
-              core.setFailed(
-                `package.json contains ${packageJson.name}@${packageJson.version}, expected fastypest@${version}.`,
-              );
+            const changelog = await readRepositoryFile('CHANGELOG.md', pullRequest.head.sha);
+            if (!changelog.includes(`[${version}]`)) {
+              core.setFailed(`CHANGELOG.md does not contain the release entry [${version}].`);
               return;
+            }
+
+            try {
+              await github.rest.repos.getReleaseByTag({ owner, repo, tag: `v${version}` });
+              core.setFailed(`GitHub Release v${version} already exists.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }
+            try {
+              await github.rest.git.getRef({ owner, repo, ref: `tags/v${version}` });
+              core.setFailed(`Git tag v${version} already exists.`);
+              return;
+            } catch (error) {
+              if (error.status !== 404) throw error;
             }
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -147,9 +216,34 @@ jobs:
         if: >-
           steps.contract.outputs.eligible == 'true' &&
           steps.contract.outputs.already_approved != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr review "$PR_URL" --approve --body "Approved by the trusted release workflow contract."
+          VALIDATED_HEAD_SHA: ${{ steps.contract.outputs.head_sha }}
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const { owner, repo } = context.repo;
+            const pullNumber = context.payload.pull_request.number;
+            const validatedHeadSha = process.env.VALIDATED_HEAD_SHA;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (pullRequest.head.sha !== validatedHeadSha) {
+              core.notice(
+                `Skipping stale approval for ${validatedHeadSha}; current head is ${pullRequest.head.sha}.`,
+              );
+              return;
+            }
+            await github.rest.pulls.createReview({
+              owner,
+              repo,
+              pull_number: pullNumber,
+              commit_id: validatedHeadSha,
+              event: 'APPROVE',
+              body: 'Approved by the trusted release workflow contract.',
+            });
 
       - name: 🔓 Enable squash auto-merge
         if: steps.contract.outputs.eligible == 'true'

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -228,8 +228,6 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.PAT_FINE }}
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 👤 Assign PR to user
         run: gh pr edit "$PR_URL" --add-assignee "${{ env.ACTOR_USERNAME }}"
         env:

--- a/.github/workflows/dependabot-auto-merge.workflow.yml
+++ b/.github/workflows/dependabot-auto-merge.workflow.yml
@@ -26,63 +26,165 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'auto-release') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login == github.repository_owner &&
-      github.event.pull_request.base.ref == github.event.repository.default_branch
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     environment: admin
     permissions:
+      contents: read
       pull-requests: write
     env:
       PR_URL: ${{ github.event.pull_request.html_url }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
-      - name: 🔎 Check current approval
-        id: check-is-approved
+      - name: 🔐 Validate current release pull request
+        id: contract
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ github.token }}
           script: |
             const { owner, repo } = context.repo;
             const pullNumber = context.payload.pull_request.number;
-            const headSha = context.payload.pull_request.head.sha;
-            const reviews = await github.paginate(
-              github.rest.pulls.listReviews,
-              { owner, repo, pull_number: pullNumber, per_page: 100 },
+            const eventHeadSha = context.payload.pull_request.head.sha;
+            const repositoryOwner = context.payload.repository.owner.login;
+            const defaultBranch = context.payload.repository.default_branch;
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            if (pullRequest.head.sha !== eventHeadSha) {
+              core.notice(
+                `Skipping stale event for ${eventHeadSha}; current head is ${pullRequest.head.sha}.`,
+              );
+              core.setOutput('eligible', 'false');
+              return;
+            }
+
+            const titleMatch = /^Bump version to v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?)$/.exec(
+              pullRequest.title,
             );
-            return reviews.some(
+            if (!titleMatch) {
+              core.setFailed(`Unexpected release pull request title: ${pullRequest.title}`);
+              return;
+            }
+
+            const version = titleMatch[1];
+            const expectedBranch = `release/v${version}`;
+            const labels = pullRequest.labels.map((label) =>
+              typeof label === 'string' ? label : label.name,
+            );
+            const trustedMetadata =
+              pullRequest.head.repo?.full_name === `${owner}/${repo}` &&
+              pullRequest.user?.login === repositoryOwner &&
+              pullRequest.base.ref === defaultBranch &&
+              pullRequest.head.ref === expectedBranch &&
+              labels.includes('auto-release');
+
+            if (!trustedMetadata) {
+              core.setFailed('Release pull request metadata violates the trusted release contract.');
+              return;
+            }
+
+            const changedFiles = (
+              await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+              })
+            )
+              .map((file) => file.filename)
+              .sort();
+            const expectedFiles = ['CHANGELOG.md', 'package.json'];
+            if (JSON.stringify(changedFiles) !== JSON.stringify(expectedFiles)) {
+              core.setFailed(
+                `Expected only ${expectedFiles.join(', ')}, received ${changedFiles.join(', ')}.`,
+              );
+              return;
+            }
+
+            const packageResponse = await github.rest.repos.getContent({
+              owner,
+              repo,
+              path: 'package.json',
+              ref: pullRequest.head.sha,
+            });
+            if (Array.isArray(packageResponse.data) || packageResponse.data.type !== 'file') {
+              core.setFailed('package.json did not resolve to a repository file.');
+              return;
+            }
+
+            const packageJson = JSON.parse(
+              Buffer.from(packageResponse.data.content, 'base64').toString('utf8'),
+            );
+            if (packageJson.version !== version || packageJson.name !== 'fastypest') {
+              core.setFailed(
+                `package.json contains ${packageJson.name}@${packageJson.version}, expected fastypest@${version}.`,
+              );
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner,
+              repo,
+              pull_number: pullNumber,
+              per_page: 100,
+            });
+            const alreadyApproved = reviews.some(
               (review) =>
                 review.user?.login === 'github-actions[bot]' &&
                 review.state === 'APPROVED' &&
-                review.commit_id === headSha,
+                review.commit_id === pullRequest.head.sha,
             );
 
+            core.setOutput('eligible', 'true');
+            core.setOutput('head_sha', pullRequest.head.sha);
+            core.setOutput('already_approved', String(alreadyApproved));
+
       - name: ✅ Approve current release head
-        if: steps.check-is-approved.outputs.result == 'false'
+        if: >-
+          steps.contract.outputs.eligible == 'true' &&
+          steps.contract.outputs.already_approved != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh pr review "$PR_URL" --approve --body "Approved by the trusted release workflow contract."
 
       - name: 🔓 Enable squash auto-merge
+        if: steps.contract.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
+          VALIDATED_HEAD_SHA: ${{ steps.contract.outputs.head_sha }}
         run: |
           set -euo pipefail
           if [[ -z "$GH_TOKEN" ]]; then
             echo "::error title=Missing release secret::Configure PAT_FINE in the admin environment."
             exit 1
           fi
+
+          actor_username=$(gh api user --jq .login)
+          if [[ "$actor_username" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid release actor::PAT_FINE authenticates as $actor_username instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
           current_head=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
-          if [[ "$current_head" != "$HEAD_SHA" ]]; then
-            echo "Skipping stale event for $HEAD_SHA; current head is $current_head."
+          if [[ "$current_head" != "$EVENT_HEAD_SHA" || "$current_head" != "$VALIDATED_HEAD_SHA" ]]; then
+            echo "Skipping stale release event; current head is $current_head."
             exit 0
           fi
+
           auto_merge_enabled=$(gh pr view "$PR_URL" --json autoMergeRequest --jq '.autoMergeRequest != null')
           if [[ "$auto_merge_enabled" == "true" ]]; then
             echo "Auto-merge is already enabled for the current release pull request."
             exit 0
           fi
+
           gh pr merge "$PR_URL" \
             --auto \
             --squash \
-            --match-head-commit "$HEAD_SHA"
+            --match-head-commit "$current_head"
 
   dependabot:
     runs-on: ubuntu-latest
@@ -97,7 +199,7 @@ jobs:
     steps:
       - name: Fetch actor username
         id: get_actor_username
-        run: echo "ACTOR_USERNAME=$(gh api user -q .login)" >> $GITHUB_ENV
+        run: echo "ACTOR_USERNAME=$(gh api user -q .login)" >> "$GITHUB_ENV"
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_FINE }}
       - name: 💿 Dependabot metadata
@@ -127,7 +229,7 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.PAT_FINE }}
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: 👤 Assign PR to user
         run: gh pr edit "$PR_URL" --add-assignee "${{ env.ACTOR_USERNAME }}"
         env:

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -102,7 +102,8 @@ jobs:
             exit 1
           fi
 
-          if ! gh label list --limit 100 --json name --jq '.[].name' | grep -Fxq auto-release; then
+          labels=$(gh label list --limit 100 --json name --jq '.[].name')
+          if ! grep -Fxq auto-release <<<"$labels"; then
             echo "::error title=Missing release label::Create the auto-release label before enabling automated releases."
             exit 1
           fi
@@ -152,8 +153,9 @@ jobs:
             --state open \
             --base "$DEFAULT_BRANCH" \
             --label auto-release \
-            --json url,headRefName,author \
-            --jq '[.[] | select(.author.login == env.GITHUB_REPOSITORY_OWNER) | select(.headRefName | startswith("release/"))][0].url // empty')
+            --author "$GITHUB_REPOSITORY_OWNER" \
+            --json url,headRefName \
+            --jq '[.[] | select(.headRefName | startswith("release/"))][0].url // empty')
           if [[ -n "$existing_pr" ]]; then
             echo "ready=false" >> "$GITHUB_OUTPUT"
             echo "Trusted release pull request already open: $existing_pr"

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -126,10 +126,21 @@ jobs:
           current_version=$(node -p "require('./package.json').version")
           current_tag="v${current_version}"
 
-          if ! gh release view "$current_tag" --json tagName >/dev/null 2>&1; then
+          if ! current_release_json=$(gh release view "$current_tag" --json tagName,isDraft,isPrerelease 2>/dev/null); then
             echo "ready=false" >> "$GITHUB_OUTPUT"
             echo "Current package version $current_version has no GitHub Release yet. Waiting for release recovery instead of preparing another version."
             exit 0
+          fi
+
+          expected_prerelease=false
+          if [[ "$current_version" == *-* ]]; then
+            expected_prerelease=true
+          fi
+          current_release_draft=$(jq -r .isDraft <<<"$current_release_json")
+          current_release_prerelease=$(jq -r .isPrerelease <<<"$current_release_json")
+          if [[ "$current_release_draft" != "false" || "$current_release_prerelease" != "$expected_prerelease" ]]; then
+            echo "::error title=Release metadata mismatch::$current_tag has draft=$current_release_draft and prerelease=$current_release_prerelease."
+            exit 1
           fi
 
           latest_tag=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName // empty')
@@ -146,6 +157,12 @@ jobs:
           release_sha=$(git rev-list -n 1 "$current_tag")
           if ! git merge-base --is-ancestor "$release_sha" HEAD; then
             echo "::error title=Invalid release baseline::$current_tag is not an ancestor of the default branch."
+            exit 1
+          fi
+          release_version=$(git show "${release_sha}:package.json" \
+            | node -e "let value=''; process.stdin.on('data', chunk => value += chunk); process.stdin.on('end', () => process.stdout.write(JSON.parse(value).version));")
+          if [[ "$release_version" != "$current_version" ]]; then
+            echo "::error title=Release package mismatch::$current_tag targets package version $release_version instead of $current_version."
             exit 1
           fi
 

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -85,6 +85,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: 🌿 Attach exact default-branch commit
+        run: git checkout -B "$DEFAULT_BRANCH" "$GITHUB_SHA"
+
       - name: 🔐 Validate release automation identity
         id: automation
         env:
@@ -167,6 +170,7 @@ jobs:
           fi
 
           existing_pr=$(gh pr list \
+            --limit 100 \
             --state open \
             --base "$DEFAULT_BRANCH" \
             --label auto-release \

--- a/.github/workflows/prepare-release.workflow.yml
+++ b/.github/workflows/prepare-release.workflow.yml
@@ -1,12 +1,13 @@
-name: 🏗️ Prepare release
+name: 🏗️ Prepare release pull request
 
 on:
-  schedule:
-    - cron: "0 7 * * *"
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       force:
-        description: "Force release"
+        description: Create a release pull request below the commit threshold
         required: true
         default: "no"
         type: choice
@@ -14,34 +15,34 @@ on:
           - "yes"
           - "no"
       strategy:
-        description: "Release strategy (if force=yes):\nmajor→2.0.0 • minor→1.1.0 • patch→1.0.1\npremajor→2.0.0-0 • preminor→1.1.0-0 • prepatch→1.0.1-0\nprerelease→1.0.1-0"
+        description: Release strategy when force is enabled
         required: true
-        default: "auto"
+        default: auto
         type: choice
         options:
-          - "auto"
-          - "major"
-          - "minor"
-          - "patch"
-          - "premajor"
-          - "preminor"
-          - "prepatch"
-          - "prerelease"
+          - auto
+          - major
+          - minor
+          - patch
+          - premajor
+          - preminor
+          - prepatch
+          - prerelease
       dry_run:
-        description: "Do everything except push, PR and publish"
-        required: false
+        description: Calculate and validate without pushing a branch or creating a pull request
+        required: true
         default: "false"
         type: choice
         options:
           - "true"
           - "false"
       breaking_change:
-        description: "Mark this release as breaking change (forces major strategy)"
+        description: Force a major release
         required: false
         default: false
         type: boolean
       breaking_change_reason:
-        description: "Breaking change note included in release changelog"
+        description: Breaking-change note added to the generated changelog
         required: false
         default: ""
         type: string
@@ -54,12 +55,16 @@ concurrency:
 
 env:
   NODE_VERSION: "22.14.0"
+  MINIMUM_COMMITS: "4"
 
-run-name: 🏗️ Prepare release${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+run-name: 🏗️ Prepare release${{ inputs.dry_run == 'true' && ' (dry run)' || '' }}
 
 jobs:
-  release:
-    name: 🚀 Prepare release${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+  prepare:
+    name: Prepare trusted release pull request
+    if: >-
+      github.event.repository.fork == false &&
+      github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: admin
@@ -68,129 +73,159 @@ jobs:
       pull-requests: read
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      FORCE_RELEASE: ${{ inputs.force || 'no' }}
+      REQUESTED_STRATEGY: ${{ inputs.strategy || 'auto' }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+      BREAKING_CHANGE: ${{ inputs.breaking_change || false }}
+      BREAKING_CHANGE_REASON: ${{ inputs.breaking_change_reason || '' }}
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: 📥 Checkout trusted default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT_FINE }}
+          persist-credentials: false
 
-      - name: 🕵️ Check release threshold
-        id: check_commits
-        env:
-          FORCE_RELEASE: ${{ github.event.inputs.force }}
-        run: |
-          set -euo pipefail
-          minimum_commits=4
-
-          if [[ "$FORCE_RELEASE" == "yes" ]]; then
-            echo "enough_commits=true" >> "$GITHUB_OUTPUT"
-            echo "Force release is enabled. Skipping commit threshold."
-            exit 0
-          fi
-
-          last_tag=$(git for-each-ref --sort=-version:refname --count=1 --format='%(refname:short)' refs/tags)
-          if [[ -z "$last_tag" ]]; then
-            commit_count=$(git rev-list --count HEAD)
-            echo "No release tag found. Counting all commits."
-          else
-            commit_count=$(git rev-list --count "${last_tag}..HEAD")
-            echo "Last tag: $last_tag"
-          fi
-          echo "Commits since release baseline: $commit_count"
-
-          if (( commit_count < minimum_commits )); then
-            echo "enough_commits=false" >> "$GITHUB_OUTPUT"
-            echo "Fewer than $minimum_commits commits are available. No release PR will be created."
-            exit 0
-          fi
-
-          echo "enough_commits=true" >> "$GITHUB_OUTPUT"
-
-      - name: 🎫 Configure Git
-        if: steps.check_commits.outputs.enough_commits == 'true'
+      - name: 🔐 Validate release automation identity
+        id: automation
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
         run: |
           set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing release secret::Configure PAT_FINE in the admin environment."
+            exit 1
+          fi
+
           actor_username=$(gh api user --jq .login)
+          if [[ "$actor_username" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid release actor::PAT_FINE authenticates as $actor_username instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+          if ! gh label list --limit 100 --json name --jq '.[].name' | grep -Fxq auto-release; then
+            echo "::error title=Missing release label::Create the auto-release label before enabling automated releases."
+            exit 1
+          fi
+
           actor_email=$(gh api user --jq '.email // empty')
           if [[ -z "$actor_email" ]]; then
             actor_email="${actor_username}@users.noreply.github.com"
           fi
-          echo "ACTOR_USERNAME=$actor_username" >> "$GITHUB_ENV"
-          git config --global user.name "$actor_username"
-          git config --global user.email "$actor_email"
+
+          git config user.name "$actor_username"
+          git config user.email "$actor_email"
+          echo "actor_username=$actor_username" >> "$GITHUB_OUTPUT"
+
+      - name: 🧭 Resolve release baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          set -euo pipefail
+          current_version=$(node -p "require('./package.json').version")
+          current_tag="v${current_version}"
+
+          if ! gh release view "$current_tag" --json tagName >/dev/null 2>&1; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Current package version $current_version has no GitHub Release yet. Waiting for release recovery instead of preparing another version."
+            exit 0
+          fi
+
+          latest_tag=$(gh release list --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName // empty')
+          if [[ -z "$latest_tag" ]]; then
+            echo "::error title=Missing release baseline::package.json is version $current_version, but no published GitHub Release was found."
+            exit 1
+          fi
+          if [[ "$latest_tag" != "$current_tag" ]]; then
+            echo "::error title=Release drift::package.json contains $current_version while the latest GitHub Release is $latest_tag."
+            exit 1
+          fi
+
+          git fetch --force origin "refs/tags/${current_tag}:refs/tags/${current_tag}"
+          release_sha=$(git rev-list -n 1 "$current_tag")
+          if ! git merge-base --is-ancestor "$release_sha" HEAD; then
+            echo "::error title=Invalid release baseline::$current_tag is not an ancestor of the default branch."
+            exit 1
+          fi
+
+          existing_pr=$(gh pr list \
+            --state open \
+            --base "$DEFAULT_BRANCH" \
+            --label auto-release \
+            --json url,headRefName,author \
+            --jq '[.[] | select(.author.login == env.GITHUB_REPOSITORY_OWNER) | select(.headRefName | startswith("release/"))][0].url // empty')
+          if [[ -n "$existing_pr" ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "Trusted release pull request already open: $existing_pr"
+            exit 0
+          fi
+
+          commit_count=$(git rev-list --count "${current_tag}..HEAD")
+          echo "Commits since $current_tag: $commit_count"
+          if [[ "$FORCE_RELEASE" != "yes" && "$commit_count" -lt "$MINIMUM_COMMITS" ]]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "At least $MINIMUM_COMMITS commits are required."
+            exit 0
+          fi
+
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+          echo "current_tag=$current_tag" >> "$GITHUB_OUTPUT"
+          echo "commit_count=$commit_count" >> "$GITHUB_OUTPUT"
 
       - name: 🟢 Setup Node.js
-        if: steps.check_commits.outputs.enough_commits == 'true'
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        if: steps.baseline.outputs.ready == 'true'
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.1.0
         with:
-          node-version: "${{ env.NODE_VERSION }}"
-          registry-url: "https://registry.npmjs.org/"
-          cache: yarn
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: ⬆️ Update npm CLI
-        if: steps.check_commits.outputs.enough_commits == 'true'
+        if: steps.baseline.outputs.ready == 'true'
         run: npm install --global npm@11.5.1
 
       - name: ⚙️ Install dependencies
-        if: steps.check_commits.outputs.enough_commits == 'true'
+        if: steps.baseline.outputs.ready == 'true'
         run: yarn install --immutable --check-cache
 
-      - name: 🚧 Run build
-        if: steps.check_commits.outputs.enough_commits == 'true'
-        run: yarn run build
+      - name: 🚧 Build package
+        if: steps.baseline.outputs.ready == 'true'
+        run: yarn build
 
-      - name: 🧪 Install package test
-        if: steps.check_commits.outputs.enough_commits == 'true'
+      - name: 🧪 Verify package installation
+        if: steps.baseline.outputs.ready == 'true'
         run: |
           set -euo pipefail
-          test_dir=$(mktemp -d)
-          yarn pack --filename "$test_dir/package.tar.gz"
-          cd "$test_dir"
+          package_dir=$(mktemp -d)
+          yarn pack --filename "$package_dir/package.tar.gz"
+          cd "$package_dir"
           yarn init -y
           touch yarn.lock
           yarn add -D ./package.tar.gz
 
       - name: 🧭 Resolve release strategy
-        if: steps.check_commits.outputs.enough_commits == 'true'
-        id: resolve_strategy
-        env:
-          REQUESTED_STRATEGY: ${{ github.event.inputs.strategy }}
-          BREAKING_CHANGE: ${{ github.event.inputs.breaking_change || 'false' }}
+        if: steps.baseline.outputs.ready == 'true'
+        id: strategy
         run: |
           set -euo pipefail
-          strategy=${REQUESTED_STRATEGY:-auto}
+          strategy="$REQUESTED_STRATEGY"
           if [[ "$BREAKING_CHANGE" == "true" ]]; then
             strategy=major
           fi
-          echo "strategy=$strategy" >> "$GITHUB_OUTPUT"
-
-      - name: ✅ Validate breaking change inputs
-        if: steps.check_commits.outputs.enough_commits == 'true'
-        env:
-          BREAKING_CHANGE: ${{ github.event.inputs.breaking_change || 'false' }}
-          BREAKING_CHANGE_REASON: ${{ github.event.inputs.breaking_change_reason }}
-        run: |
-          set -euo pipefail
           if [[ "$BREAKING_CHANGE" == "true" && -z "$BREAKING_CHANGE_REASON" ]]; then
-            echo "breaking_change_reason is required when breaking_change is true"
+            echo "::error title=Missing breaking-change reason::breaking_change_reason is required."
             exit 1
           fi
+          echo "value=$strategy" >> "$GITHUB_OUTPUT"
 
-      - name: 🆙 Dry run release
-        if: steps.check_commits.outputs.enough_commits == 'true' && github.event.inputs.dry_run == 'true'
+      - name: 🧪 Calculate release without delivery
+        if: steps.baseline.outputs.ready == 'true' && env.DRY_RUN == 'true'
         env:
-          STRATEGY: ${{ steps.resolve_strategy.outputs.strategy }}
-          BREAKING_CHANGE: ${{ github.event.inputs.breaking_change || 'false' }}
-          BREAKING_CHANGE_REASON: ${{ github.event.inputs.breaking_change_reason }}
+          STRATEGY: ${{ steps.strategy.outputs.value }}
         run: |
           set -euo pipefail
-          git checkout "$DEFAULT_BRANCH"
-          git pull --ff-only origin "$DEFAULT_BRANCH"
           if [[ "$BREAKING_CHANGE" == "true" ]]; then
-            git commit --allow-empty -m "feat!: mark breaking change release" -m "BREAKING CHANGE: $BREAKING_CHANGE_REASON"
+            git commit --allow-empty \
+              -m "feat!: mark breaking change release" \
+              -m "BREAKING CHANGE: $BREAKING_CHANGE_REASON"
           fi
           if [[ "$STRATEGY" == "auto" ]]; then
             yarn release --dry-run
@@ -198,55 +233,20 @@ jobs:
             yarn release --release-as "$STRATEGY" --dry-run
           fi
 
-      - name: 📝 Prepare release pull request
-        if: steps.check_commits.outputs.enough_commits == 'true' && github.event.inputs.dry_run != 'true'
-        id: prepare_release
+      - name: 📝 Create release pull request
+        if: steps.baseline.outputs.ready == 'true' && env.DRY_RUN != 'true'
+        id: pull_request
         env:
           GH_TOKEN: ${{ secrets.PAT_FINE }}
-          STRATEGY: ${{ steps.resolve_strategy.outputs.strategy }}
-          BREAKING_CHANGE: ${{ github.event.inputs.breaking_change || 'false' }}
-          BREAKING_CHANGE_REASON: ${{ github.event.inputs.breaking_change_reason }}
+          STRATEGY: ${{ steps.strategy.outputs.value }}
+          ACTOR_USERNAME: ${{ steps.automation.outputs.actor_username }}
+          COMMIT_COUNT: ${{ steps.baseline.outputs.commit_count }}
         run: |
           set -euo pipefail
-          release_branch="release/${GITHUB_RUN_NUMBER}"
-
-          if git ls-remote --exit-code --heads origin "$release_branch" >/dev/null 2>&1; then
-            existing_pr=$(gh pr list --head "$release_branch" --base "$DEFAULT_BRANCH" --state open --json url --jq '.[0].url // empty')
-            if [[ -z "$existing_pr" ]]; then
-              echo "::error title=Release branch collision::$release_branch exists without an open pull request."
-              exit 1
-            fi
-            head_sha=$(gh pr view "$existing_pr" --json headRefOid --jq .headRefOid)
-            release_title=$(gh pr view "$existing_pr" --json title --jq .title)
-            if [[ "$release_title" != "Bump version to v"* ]]; then
-              echo "::error title=Invalid existing release PR::$existing_pr has unexpected title '$release_title'."
-              exit 1
-            fi
-            release_tag=${release_title#Bump version to }
-            git fetch origin "refs/heads/${release_branch}:refs/remotes/origin/${release_branch}"
-            remote_head=$(git rev-parse "refs/remotes/origin/${release_branch}")
-            if [[ "$remote_head" != "$head_sha" ]]; then
-              echo "::error title=Release head mismatch::$release_branch points to $remote_head but the pull request reports $head_sha."
-              exit 1
-            fi
-            head_version=$(git show "${remote_head}:package.json" | jq -r .version)
-            if [[ "v${head_version}" != "$release_tag" ]]; then
-              echo "::error title=Release version mismatch::PR title resolves to $release_tag but package.json contains $head_version."
-              exit 1
-            fi
-            gh pr edit "$existing_pr" --add-label auto-release --add-assignee "$ACTOR_USERNAME"
-            echo "pr_url=$existing_pr" >> "$GITHUB_OUTPUT"
-            echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-            echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git checkout "$DEFAULT_BRANCH"
-          git pull --ff-only origin "$DEFAULT_BRANCH"
-          git checkout -b "$release_branch"
-
           if [[ "$BREAKING_CHANGE" == "true" ]]; then
-            git commit --allow-empty -m "feat!: mark breaking change release" -m "BREAKING CHANGE: $BREAKING_CHANGE_REASON"
+            git commit --allow-empty \
+              -m "feat!: mark breaking change release" \
+              -m "BREAKING CHANGE: $BREAKING_CHANGE_REASON"
           fi
 
           if [[ "$STRATEGY" == "auto" ]]; then
@@ -257,40 +257,58 @@ jobs:
 
           release_version=$(node -p "require('./package.json').version")
           release_tag="v${release_version}"
+          release_branch="release/${release_tag}"
+
           if ! git rev-parse --verify "refs/tags/${release_tag}" >/dev/null 2>&1; then
-            echo "::error title=Missing local release tag::standard-version did not create ${release_tag}."
+            echo "::error title=Missing generated tag::standard-version did not create $release_tag."
             exit 1
           fi
           git tag -d "$release_tag"
-          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
-            echo "::error title=Remote release tag collision::$release_tag already exists on origin."
+
+          if gh release view "$release_tag" >/dev/null 2>&1; then
+            echo "::error title=Release already exists::GitHub Release $release_tag already exists."
             exit 1
           fi
-          git push origin "HEAD:refs/heads/${release_branch}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${release_tag}" >/dev/null 2>&1; then
+            echo "::error title=Tag collision::Remote tag $release_tag already exists."
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "refs/heads/${release_branch}" >/dev/null 2>&1; then
+            echo "::error title=Release branch collision::$release_branch already exists."
+            exit 1
+          fi
+
+          git branch -m "$release_branch"
+          authorization=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+          echo "::add-mask::$authorization"
+          git -c http.extraheader="Authorization: Basic $authorization" \
+            push origin "HEAD:refs/heads/${release_branch}"
 
           pr_url=$(gh pr create \
             --base "$DEFAULT_BRANCH" \
             --head "$release_branch" \
             --title "Bump version to ${release_tag}" \
-            --body "Bumps version to ${release_tag}. Publication starts only after this pull request is merged by the repository requirements.")
-          gh pr edit "$pr_url" --add-label auto-release --add-assignee "$ACTOR_USERNAME"
+            --label auto-release \
+            --assignee "$ACTOR_USERNAME" \
+            --body "Automated release from ${COMMIT_COUNT} commits. The trusted release workflow validates and approves this exact head, then repository requirements control squash auto-merge.")
 
           head_sha=$(git rev-parse HEAD)
-          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
 
       - name: 📋 Report release pull request
-        if: steps.prepare_release.outputs.pr_url != ''
+        if: steps.pull_request.outputs.url != ''
         env:
-          PR_URL: ${{ steps.prepare_release.outputs.pr_url }}
-          HEAD_SHA: ${{ steps.prepare_release.outputs.head_sha }}
-          RELEASE_TAG: ${{ steps.prepare_release.outputs.release_tag }}
+          PR_URL: ${{ steps.pull_request.outputs.url }}
+          HEAD_SHA: ${{ steps.pull_request.outputs.head_sha }}
+          RELEASE_TAG: ${{ steps.pull_request.outputs.release_tag }}
         run: |
           {
-            echo "### Release pull request prepared"
+            echo "### Release pull request created"
             echo "- Pull request: $PR_URL"
             echo "- Head: $HEAD_SHA"
             echo "- Version: $RELEASE_TAG"
-            echo "- Delivery: repository requirements and auto-merge"
+            echo "- Approval: trusted release contract workflow"
+            echo "- Merge: repository requirements and squash auto-merge"
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What
- trigger release preparation from default-branch pushes and preserve manual dry-run, strategy, and recovery controls
- create a dedicated workflow that resolves the exact version-introducing commit, creates an immutable tag, and publishes generated GitHub Release notes
- keep `.github/workflows/auto-release.workflow.yml` unchanged as the npm trusted-publisher identity, now triggered by `release.published`
- validate and auto-approve trusted release PRs against the exact current head before enabling repository-controlled squash auto-merge
- document the scoped PAT/OIDC trust boundaries and workflow ownership

## Why
Release preparation, GitHub Release creation, and npm publication are independent state transitions. Separating them removes custom coupling to pull-request closure while allowing both automated and manual GitHub Releases to use the same npm OIDC publisher.

## Security and integrity
- `PAT_FINE` is restricted to the protected `admin` environment and used only for event-emitting transitions
- the authenticated PAT actor must be the repository owner
- `pull_request_target` never checks out or executes pull-request code
- release PR approval validates the live SHA, exact branch/title, same-repository owner author, base branch, exact changed files, monotonic SemVer, changelog entry, package identity, and destination tag/release state
- the approval review is created with the exact validated commit ID and the existing message: `Approved by the trusted release workflow contract.`
- auto-merge uses squash and `--match-head-commit`; repository requirements remain the merge authority
- release preparation is attached to the exact default-branch event SHA
- GitHub Release creation resolves the first-parent commit that introduced the package version, including multi-commit pushes
- existing tags/releases are accepted only when target and metadata match; collisions fail without force updates or destructive cleanup
- npm publication uses OIDC only, validates tag/default-branch ancestry, and sends prereleases to `next`
- third-party Actions in changed workflows are pinned to full commit SHAs

## Validation
- workflow YAML parsing passed
- every changed shell block passed `bash -n` after GitHub-expression neutralization
- every changed `actions/github-script` program passed JavaScript syntax validation
- static contract assertions passed for responsibility separation, pinned Actions, immutable tags, PAT/OIDC boundaries, and absence of npm token fallback
- exact release-SHA synthetic tests passed for multi-commit push, manual recovery, and later same-version package metadata changes
- strict SemVer parser/comparator cases passed
- all five initial review findings were corrected and all review threads are resolved
- CodeRabbit combined status is green on final head
- pull-request CI run `30647677476` passed on head `b2c4e1459511f4de0512ad844014883c7568c8db`
- build, format, package installation smoke, MySQL, PostgreSQL, MariaDB, CockroachDB, and final check-all jobs passed

## Impact
After merge, every default-branch update evaluates the release threshold. A generated version PR is validated and approved automatically but merges only after repository requirements pass. Its version-changing merge creates the GitHub Release from the exact version-introducing commit, and the resulting `release.published` event invokes the existing npm trusted-publisher workflow. Manually published owner releases use the same npm path.

This implementation PR is not labeled `auto-release`, does not change `package.json`, and cannot create a tag, GitHub Release, or npm publication.

## Rollback
Revert this pull request. No tags, releases, npm versions, or generated release branches have been created by this implementation.