### PR TITLE
Bump version to v3.0.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.0.42](https://github.com/juanjoGonDev/fastypest/compare/v3.0.41...v3.0.42) (2026-08-08)
+
 ### [3.0.41](https://github.com/juanjoGonDev/fastypest/compare/v3.0.40...v3.0.41) (2026-08-06)
 
 ### [3.0.40](https://github.com/juanjoGonDev/fastypest/compare/v3.0.39...v3.0.40) (2026-07-31)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastypest",
-  "version": "3.0.41",
+  "version": "3.0.42",
   "description": "Restores the database automatically after each test. Allows serial execution of tests without having to delete and restore the database having to stop the application",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Automated release from 4 commits. The trusted release workflow validates and approves this exact head, then repository requirements control squash auto-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package version to 3.0.42.
  - Added a changelog entry for the 3.0.42 release dated August 8, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->