### PR TITLE
fix(actions): harden release and required QA runtime

### DIFF
--- a/.agents/specs/2026-08-08-actions-runtime-hardening.md
+++ b/.agents/specs/2026-08-08-actions-runtime-hardening.md
@@ -1,0 +1,44 @@
+# Actions runtime hardening
+
+## Request
+
+Investigate the failing npm auto-release and the shared required-QA Dependabot auto-merge automation, correct the root causes, and preserve the trusted release and approval contracts.
+
+## Evidence
+
+- Auto-release run `31248972629`, job `93082148311`, reached the package consumer smoke test and failed before publication because `actions/setup-node` exported an npm user config containing `${NODE_AUTH_TOKEN}` while npm trusted publishing intentionally provides no long-lived token. The temporary consumer then resolved Yarn Classic outside the repository and attempted to expand that undefined variable.
+- Required-QA workflows shared across the repository set attempt `enablePullRequestAutoMerge` even when GitHub reports a PR as `clean`; GitHub rejects that mutation because the PR can already merge.
+- Updating a behind Dependabot branch that changes `.github/workflows/*` can return `403` unless the automation token has the sensitive Workflows permission.
+- `GITHUB_TOKEN` must not perform an immediate merge when downstream `push` workflows are required because GitHub suppresses most workflow runs caused by that token.
+
+## Decision
+
+- Keep `.github/workflows/auto-release.workflow.yml` at the same path and retain npm OIDC with `id-token: write`; do not add an npm token fallback.
+- Isolate only the package-install smoke test from the publisher npm config and run its consumer install with the package-manager version declared by the package.
+- Keep current-head, non-bot, write-maintainer QA approval as the merge prerequisite and revalidate it immediately before mutation.
+- Use the protected `admin` Actions secret `PAT_FINE`, validated as the repository owner, for live branch/merge transitions so downstream events remain eligible to start workflows.
+- Never grant Workflows permission for branch refresh. A behind PR that changes workflows is reported as requiring a manual trusted branch update and a fresh approval.
+- If GitHub already reports `clean`, squash-merge the exact approved head. Otherwise enable repository auto-merge when available; handle a clean-state race by revalidating and merging the same exact head.
+
+## Acceptance
+
+- The npm smoke test no longer depends on `NODE_AUTH_TOKEN` and the OIDC publisher identity is unchanged.
+- Clean approved majors no longer fail the auto-merge mutation.
+- Workflow-changing behind majors do not request elevated workflow permission.
+- Stale approvals, bot approvals, changed heads, merge conflicts and change-request reviews cannot merge.
+- Dry-run remains non-mutating.
+
+## Checks
+
+- Parse changed workflow YAML.
+- Syntax-check shell and `github-script` programs.
+- Verify changed third-party Actions use immutable SHAs.
+- Pull-request CI is authoritative.
+
+## Rollback
+
+Revert the corrective pull request. No release, npm publish, merge, or deployment is performed by this branch.
+
+## Delivery status
+
+Implemented on `agent/fix-actions-runtime-20260808`; pending pull-request CI and explicit owner merge approval.

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -80,8 +80,10 @@ jobs:
             const defaultBranch = context.payload.repository.default_branch;
             const repository = await github.rest.repos.get({ owner, repo });
             const autoMergeAllowed = repository.data.allow_auto_merge === true;
+            const hasRequiredQaLabel = (pullRequest) => pullRequest.labels.some((label) => label.name === 'requires-manual-qa');
+            const isTrustedCandidate = (pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && hasRequiredQaLabel(pullRequest);
             const pullRequests = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
-            const candidates = pullRequests.filter((pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && pullRequest.labels.some((label) => label.name === 'requires-manual-qa'));
+            const candidates = pullRequests.filter(isTrustedCandidate);
             const permissionCache = new Map();
             const decisiveReviewStates = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
             const hasWritePermission = async (login) => {
@@ -130,6 +132,7 @@ jobs:
               try {
                 const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
                 const currentHeadSha = current.data.head.sha;
+                if (!isTrustedCandidate(current.data)) { results.push({ number: candidate.number, action: 'skipped', reason: 'candidate trust contract changed' }); continue; }
                 if (current.data.mergeable_state === 'behind') {
                   if (await hasWorkflowChanges(candidate.number)) { results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' }); continue; }
                   if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
@@ -145,6 +148,7 @@ jobs:
                 const approval = await readApprovalState(candidate.number, currentHeadSha);
                 if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
                 const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                if (!isTrustedCandidate(verified.data)) { results.push({ number: candidate.number, action: 'skipped', reason: 'candidate trust contract changed during validation' }); continue; }
                 if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
                 const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
                 if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
@@ -159,7 +163,7 @@ jobs:
                     if (!becameClean) throw error;
                     const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
                     const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
-                    if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
+                    if (!isTrustedCandidate(clean.data) || clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
                     await mergeCleanPullRequest(candidate.number, currentHeadSha);
                     results.push({ number: candidate.number, action: 'merged-after-clean-race' });
                     continue;

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ -z "$GH_TOKEN" ]]; then
-            echo "::error title=Missing Actions secret::Configure PAT_FINE in the protected admin environment with Pull requests read/write permission."
+            echo "::error title=Missing Actions secret::Configure PAT_FINE in the protected admin environment with Contents and Pull requests write permission."
             exit 1
           fi
           authenticated_login=$(gh api user --jq .login)
@@ -83,6 +83,7 @@ jobs:
             const pullRequests = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
             const candidates = pullRequests.filter((pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && pullRequest.labels.some((label) => label.name === 'requires-manual-qa'));
             const permissionCache = new Map();
+            const decisiveReviewStates = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
             const hasWritePermission = async (login) => {
               if (permissionCache.has(login)) return permissionCache.get(login);
               try {
@@ -101,7 +102,7 @@ jobs:
               for (const review of reviews) {
                 const login = review.user?.login;
                 const submittedAt = Date.parse(review.submitted_at ?? '');
-                if (!login || !Number.isFinite(submittedAt) || review.commit_id !== headSha) continue;
+                if (!login || !Number.isFinite(submittedAt) || review.commit_id !== headSha || !decisiveReviewStates.has(review.state)) continue;
                 const previous = latestReviewByUser.get(login);
                 if (!previous || submittedAt > previous.submittedAt) latestReviewByUser.set(login, { state: review.state, submittedAt });
               }
@@ -120,47 +121,55 @@ jobs:
             };
             const mergeCleanPullRequest = async (pullNumber, headSha) => {
               const merge = await github.rest.pulls.merge({ owner, repo, pull_number: pullNumber, merge_method: 'squash', sha: headSha });
-              if (!merge.data.merged) throw new Error(`GitHub did not merge #${pullNumber}: ${merge.data.message}`);
+              if (!merge.data.merged) throw new Error(`GitHub did not merge #${pullNumber}`);
             };
+            const failureReason = (error) => Number.isInteger(error?.status) ? `GitHub request failed with HTTP ${error.status}` : 'GitHub request failed unexpectedly';
             const results = [];
+            let failures = 0;
             for (const candidate of candidates) {
-              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-              const currentHeadSha = current.data.head.sha;
-              if (current.data.mergeable_state === 'behind') {
-                if (await hasWorkflowChanges(candidate.number)) { results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' }); continue; }
-                if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
-                try { await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: currentHeadSha }); } catch (error) {
-                  const workflowPermissionFailure = error.status === 403 && String(error.message).includes('workflows permission');
-                  if (!workflowPermissionFailure) throw error;
-                  results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'GitHub refused the branch update because workflow-file changes require workflows permission' });
+              try {
+                const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                const currentHeadSha = current.data.head.sha;
+                if (current.data.mergeable_state === 'behind') {
+                  if (await hasWorkflowChanges(candidate.number)) { results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' }); continue; }
+                  if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
+                  try { await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: currentHeadSha }); } catch (error) {
+                    const workflowPermissionFailure = error.status === 403 && String(error.message).includes('workflows permission');
+                    if (!workflowPermissionFailure) throw error;
+                    results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'GitHub refused the branch update because workflow-file changes require workflows permission' });
+                    continue;
+                  }
+                  results.push({ number: candidate.number, action: 'branch-update-requested', reason: 'fresh approval required for the new head commit' });
                   continue;
                 }
-                results.push({ number: candidate.number, action: 'branch-update-requested', reason: 'fresh approval required for the new head commit' });
-                continue;
-              }
-              const approval = await readApprovalState(candidate.number, currentHeadSha);
-              if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
-              const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-              if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
-              const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
-              if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
-              if (verified.data.mergeable_state === 'behind') { results.push({ number: candidate.number, action: 'skipped', reason: 'branch became outdated during validation' }); continue; }
-              if (verified.data.mergeable_state === 'dirty' || verified.data.mergeable_state === 'unknown') { results.push({ number: candidate.number, action: 'skipped', reason: `merge state is ${verified.data.mergeable_state}` }); continue; }
-              if (dryRun) { results.push({ number: candidate.number, action: verified.data.mergeable_state === 'clean' ? 'would-merge' : autoMergeAllowed ? 'would-enable-auto-merge' : 'would-wait-for-requirements' }); continue; }
-              if (verified.data.mergeable_state === 'clean') { await mergeCleanPullRequest(candidate.number, currentHeadSha); results.push({ number: candidate.number, action: 'merged' }); continue; }
-              if (!autoMergeAllowed) { results.push({ number: candidate.number, action: 'waiting-for-requirements', reason: 'repository auto-merge is disabled; a later run will merge once GitHub reports clean' }); continue; }
-              if (!verified.data.auto_merge) {
-                try { await github.graphql(`mutation EnableAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId mergeMethod: SQUASH expectedHeadOid: $expectedHeadOid }) { pullRequest { number } } }`, { pullRequestId: verified.data.node_id, expectedHeadOid: currentHeadSha }); } catch (error) {
-                  const becameClean = error.errors?.some((entry) => String(entry.message).includes('clean status'));
-                  if (!becameClean) throw error;
-                  const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
-                  const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
-                  if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
-                  await mergeCleanPullRequest(candidate.number, currentHeadSha);
-                  results.push({ number: candidate.number, action: 'merged-after-clean-race' });
-                  continue;
+                const approval = await readApprovalState(candidate.number, currentHeadSha);
+                if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
+                const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
+                const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
+                if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
+                if (verified.data.mergeable_state === 'behind') { results.push({ number: candidate.number, action: 'skipped', reason: 'branch became outdated during validation' }); continue; }
+                if (verified.data.mergeable_state === 'dirty' || verified.data.mergeable_state === 'unknown') { results.push({ number: candidate.number, action: 'skipped', reason: `merge state is ${verified.data.mergeable_state}` }); continue; }
+                if (dryRun) { results.push({ number: candidate.number, action: verified.data.mergeable_state === 'clean' ? 'would-merge' : autoMergeAllowed ? 'would-enable-auto-merge' : 'would-wait-for-requirements' }); continue; }
+                if (verified.data.mergeable_state === 'clean') { await mergeCleanPullRequest(candidate.number, currentHeadSha); results.push({ number: candidate.number, action: 'merged' }); continue; }
+                if (!autoMergeAllowed) { results.push({ number: candidate.number, action: 'waiting-for-requirements', reason: 'repository auto-merge is disabled; a later run will merge once GitHub reports clean' }); continue; }
+                if (!verified.data.auto_merge) {
+                  try { await github.graphql(`mutation EnableAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId mergeMethod: SQUASH expectedHeadOid: $expectedHeadOid }) { pullRequest { number } } }`, { pullRequestId: verified.data.node_id, expectedHeadOid: currentHeadSha }); } catch (error) {
+                    const becameClean = error.errors?.some((entry) => String(entry.message).includes('clean status'));
+                    if (!becameClean) throw error;
+                    const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                    const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
+                    if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
+                    await mergeCleanPullRequest(candidate.number, currentHeadSha);
+                    results.push({ number: candidate.number, action: 'merged-after-clean-race' });
+                    continue;
+                  }
                 }
+                results.push({ number: candidate.number, action: 'auto-merge-enabled' });
+              } catch (error) {
+                failures += 1;
+                results.push({ number: candidate.number, action: 'failed', reason: failureReason(error) });
               }
-              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
             }
             await core.summary.addHeading('Required QA auto-merge').addRaw(results.length === 0 ? 'No eligible Dependabot pull requests found.' : results.map((result) => `- #${result.number}: ${result.action}${result.reason ? ` — ${result.reason}` : ''}`).join('\n')).write();
+            if (failures > 0) core.setFailed(`${failures} Dependabot pull request(s) failed processing.`);

--- a/.github/workflows/auto-merge-required-qa.workflow.yml
+++ b/.github/workflows/auto-merge-required-qa.workflow.yml
@@ -1,4 +1,4 @@
-name: 🔄 PRs Required QA Auto-Merge
+name: 🔄 Required QA auto-merge
 
 on:
   schedule:
@@ -6,154 +6,161 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Do not actually merge, just simulate (for testing)"
-        required: false
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
+        description: Report eligible pull requests without changing branches or merge state
+        required: true
+        default: true
+        type: boolean
 
-run-name: 🔄 PRs Required QA Auto-Merge${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+permissions: read-all
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: required-qa-auto-merge
+  cancel-in-progress: false
 
 jobs:
-  auto-merge-required-qa:
-    name: Auto merge required QA${{ github.event.inputs.dry_run == 'true' && ' (dry)' || '' }}
+  process:
+    name: Process approved Dependabot majors
+    if: github.event.repository.fork == false
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: admin
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v7
-
-      - name: 🔍 Search PRs requires-manual-qa
-        id: search_prs
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prs = await github.rest.pulls.list({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              per_page: 100
-            });
-            // Filter by label, dependabot and base main
-            const filtered = prs.data.filter(pr =>
-              pr.labels.some(l => l.name === 'requires-manual-qa') &&
-              pr.user.login === 'dependabot[bot]' &&
-              pr.base.ref === 'main' &&
-              pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`
-            );
-            return filtered.map(pr => pr.number);
-
-      - name: 🤖 Process PRs
-        if: steps.search_prs.outputs.result != '[]'
-        uses: actions/github-script@v9
+      - name: Synchronize automation labels
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          dry_run: ${{ github.event.inputs.dry_run }}
-          GH_TOKEN: ${{ secrets.PAT_FINE }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
         with:
-          github-token: ${{ secrets.PAT_FINE }}
+          github-token: ${{ github.token }}
           script: |
-            const dryRun = process.env.dry_run === 'true';
-            console.log(`Dry run mode: ${dryRun}`);
-
-            let prNumbers = ${{ steps.search_prs.outputs.result }};
-            if (typeof prNumbers === 'string') {
-              try {
-                prNumbers = JSON.parse(prNumbers);
-              } catch {
-                prNumbers = [];
+            const dryRun = process.env.DRY_RUN === 'true';
+            const { owner, repo } = context.repo;
+            const labels = [{ name: 'requires-manual-qa', color: 'E99695', description: 'Needs manual quality assurance testing before merging' }];
+            const updateLabel = (label) => github.rest.issues.updateLabel({ owner, repo, name: label.name, new_name: label.name, color: label.color, description: label.description });
+            for (const label of labels) {
+              if (dryRun) { core.info(`Would synchronize label ${label.name}.`); continue; }
+              try { await updateLabel(label); } catch (error) {
+                if (error.status !== 404) throw error;
+                try { await github.rest.issues.createLabel({ owner, repo, ...label }); } catch (createError) {
+                  const duplicate = createError.status === 422 && createError.response?.data?.errors?.some((entry) => entry.code === 'already_exists');
+                  if (!duplicate) throw createError;
+                  await updateLabel(label);
+                }
               }
             }
+
+      - name: Validate trusted merge identity
+        if: inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.PAT_FINE }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error title=Missing Actions secret::Configure PAT_FINE in the protected admin environment with Pull requests read/write permission."
+            exit 1
+          fi
+          authenticated_login=$(gh api user --jq .login)
+          if [[ "$authenticated_login" != "$GITHUB_REPOSITORY_OWNER" ]]; then
+            echo "::error title=Invalid merge actor::PAT_FINE authenticates as $authenticated_login instead of $GITHUB_REPOSITORY_OWNER."
+            exit 1
+          fi
+
+      - name: Validate current approvals and queue or merge
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          DRY_RUN: ${{ inputs.dry_run || false }}
+        with:
+          github-token: ${{ inputs.dry_run == true && github.token || secrets.PAT_FINE }}
+          script: |
+            const dryRun = process.env.DRY_RUN === 'true';
+            const { owner, repo } = context.repo;
+            const defaultBranch = context.payload.repository.default_branch;
+            const repository = await github.rest.repos.get({ owner, repo });
+            const autoMergeAllowed = repository.data.allow_auto_merge === true;
+            const pullRequests = await github.paginate(github.rest.pulls.list, { owner, repo, state: 'open', per_page: 100 });
+            const candidates = pullRequests.filter((pullRequest) => pullRequest.user?.login === 'dependabot[bot]' && pullRequest.base.ref === defaultBranch && pullRequest.head.repo?.full_name === `${owner}/${repo}` && pullRequest.labels.some((label) => label.name === 'requires-manual-qa'));
+            const permissionCache = new Map();
+            const hasWritePermission = async (login) => {
+              if (permissionCache.has(login)) return permissionCache.get(login);
+              try {
+                const response = await github.rest.repos.getCollaboratorPermissionLevel({ owner, repo, username: login });
+                const allowed = ['admin', 'maintain', 'write'].includes(response.data.permission);
+                permissionCache.set(login, allowed);
+                return allowed;
+              } catch (error) {
+                if (error.status === 404) { permissionCache.set(login, false); return false; }
+                throw error;
+              }
+            };
+            const readApprovalState = async (pullNumber, headSha) => {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, { owner, repo, pull_number: pullNumber, per_page: 100 });
+              const latestReviewByUser = new Map();
+              for (const review of reviews) {
+                const login = review.user?.login;
+                const submittedAt = Date.parse(review.submitted_at ?? '');
+                if (!login || !Number.isFinite(submittedAt) || review.commit_id !== headSha) continue;
+                const previous = latestReviewByUser.get(login);
+                if (!previous || submittedAt > previous.submittedAt) latestReviewByUser.set(login, { state: review.state, submittedAt });
+              }
+              let approved = false;
+              let changesRequested = false;
+              for (const [login, review] of latestReviewByUser) {
+                if (login.endsWith('[bot]') || !(await hasWritePermission(login))) continue;
+                approved ||= review.state === 'APPROVED';
+                changesRequested ||= review.state === 'CHANGES_REQUESTED';
+              }
+              return { approved, changesRequested };
+            };
+            const hasWorkflowChanges = async (pullNumber) => {
+              const files = await github.paginate(github.rest.pulls.listFiles, { owner, repo, pull_number: pullNumber, per_page: 100 });
+              return files.some((file) => file.filename.startsWith('.github/workflows/'));
+            };
+            const mergeCleanPullRequest = async (pullNumber, headSha) => {
+              const merge = await github.rest.pulls.merge({ owner, repo, pull_number: pullNumber, merge_method: 'squash', sha: headSha });
+              if (!merge.data.merged) throw new Error(`GitHub did not merge #${pullNumber}: ${merge.data.message}`);
+            };
             const results = [];
-
-            for (const prNumber of prNumbers) {
-              console.log(`PR #${prNumber}: Processing...`);
-
-              let pr = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              // 1. Check if approved
-
-              console.log(`PR #${prNumber}: Checking if  is approved...`);
-              const reviews = await github.rest.pulls.listReviews({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-
-              const approved = reviews.data.some(r => r.state === 'APPROVED');
-              if (!approved) {
-                console.log(`PR #${prNumber}: is NOT approved.`);
-                results.push({prNumber, merged: false, reason: 'No approved'});
+            for (const candidate of candidates) {
+              const current = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+              const currentHeadSha = current.data.head.sha;
+              if (current.data.mergeable_state === 'behind') {
+                if (await hasWorkflowChanges(candidate.number)) { results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'branch is behind and changes workflow files; automation will not request workflows permission' }); continue; }
+                if (dryRun) { results.push({ number: candidate.number, action: 'would-update-branch', reason: 'fresh approval required after the update' }); continue; }
+                try { await github.rest.pulls.updateBranch({ owner, repo, pull_number: candidate.number, expected_head_sha: currentHeadSha }); } catch (error) {
+                  const workflowPermissionFailure = error.status === 403 && String(error.message).includes('workflows permission');
+                  if (!workflowPermissionFailure) throw error;
+                  results.push({ number: candidate.number, action: 'manual-branch-update-required', reason: 'GitHub refused the branch update because workflow-file changes require workflows permission' });
+                  continue;
+                }
+                results.push({ number: candidate.number, action: 'branch-update-requested', reason: 'fresh approval required for the new head commit' });
                 continue;
               }
-              console.log(`PR #${prNumber}: is approved.`);
-
-              // 2. Enable auto-merge
-              if (!dryRun) {
-                try {
-                  const result = await github.graphql(`
-                    mutation EnableAutoMerge($pullRequestId: ID!) {
-                      enablePullRequestAutoMerge(input: {
-                        pullRequestId: $pullRequestId,
-                        mergeMethod: SQUASH
-                      }) {
-                        pullRequest {
-                          number
-                          autoMergeRequest {
-                            enabledAt
-                            enabledBy {
-                              login
-                            }
-                          }
-                        }
-                      }
-                    }
-                  `, {
-                    pullRequestId: pr.data.node_id,
-                    headers: {
-                      Authorization: `token ${process.env.GH_TOKEN}`
-                    }
-                  });
-
-                  console.log(`PR #${prNumber}: Auto-merge enabled.`);
-                  results.push({ prNumber, merged: true, reason: 'Auto-merge enabled' });
-                } catch (e) {
-                  console.log(`PR #${prNumber}: Auto-merge failed: ${e.message}`);
-                  results.push({ prNumber, merged: false, reason: 'Auto-merge failed: ' + e.message });
-                }
-              } else {
-                console.log(`PR #${prNumber}: Dry run, auto-merge skipped.`);
-                results.push({ prNumber, merged: false, reason: 'Dry run: auto-merge skipped' });
-              }
-
-              // 3. Updated with main
-              let updated = pr.data.mergeable_state === 'clean';
-
-              if (!updated) {
-                console.log(`PR #${prNumber}: is NOT up-to-date. Attempting to update...`);
-                try {
-                  await github.rest.pulls.updateBranch({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: prNumber
-                  });
-                  console.log(`PR #${prNumber}: update triggered.`);
-                } catch (e) {
-                  console.log(`PR #${prNumber}: update FAILED: ${e.message}`);
-                  results.push({prNumber, merged: false, reason: 'Could not update branch: ' + e.message});
+              const approval = await readApprovalState(candidate.number, currentHeadSha);
+              if (!approval.approved || approval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: approval.changesRequested ? 'current maintainer review requests changes' : 'no maintainer approval for the current head commit' }); continue; }
+              const verified = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+              if (verified.data.head.sha !== currentHeadSha) { results.push({ number: candidate.number, action: 'skipped', reason: 'head commit changed during validation' }); continue; }
+              const verifiedApproval = await readApprovalState(candidate.number, currentHeadSha);
+              if (!verifiedApproval.approved || verifiedApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'maintainer approval changed during validation' }); continue; }
+              if (verified.data.mergeable_state === 'behind') { results.push({ number: candidate.number, action: 'skipped', reason: 'branch became outdated during validation' }); continue; }
+              if (verified.data.mergeable_state === 'dirty' || verified.data.mergeable_state === 'unknown') { results.push({ number: candidate.number, action: 'skipped', reason: `merge state is ${verified.data.mergeable_state}` }); continue; }
+              if (dryRun) { results.push({ number: candidate.number, action: verified.data.mergeable_state === 'clean' ? 'would-merge' : autoMergeAllowed ? 'would-enable-auto-merge' : 'would-wait-for-requirements' }); continue; }
+              if (verified.data.mergeable_state === 'clean') { await mergeCleanPullRequest(candidate.number, currentHeadSha); results.push({ number: candidate.number, action: 'merged' }); continue; }
+              if (!autoMergeAllowed) { results.push({ number: candidate.number, action: 'waiting-for-requirements', reason: 'repository auto-merge is disabled; a later run will merge once GitHub reports clean' }); continue; }
+              if (!verified.data.auto_merge) {
+                try { await github.graphql(`mutation EnableAutoMerge($pullRequestId: ID!, $expectedHeadOid: GitObjectID!) { enablePullRequestAutoMerge(input: { pullRequestId: $pullRequestId mergeMethod: SQUASH expectedHeadOid: $expectedHeadOid }) { pullRequest { number } } }`, { pullRequestId: verified.data.node_id, expectedHeadOid: currentHeadSha }); } catch (error) {
+                  const becameClean = error.errors?.some((entry) => String(entry.message).includes('clean status'));
+                  if (!becameClean) throw error;
+                  const clean = await github.rest.pulls.get({ owner, repo, pull_number: candidate.number });
+                  const cleanApproval = await readApprovalState(candidate.number, currentHeadSha);
+                  if (clean.data.head.sha !== currentHeadSha || clean.data.mergeable_state !== 'clean' || !cleanApproval.approved || cleanApproval.changesRequested) { results.push({ number: candidate.number, action: 'skipped', reason: 'pull request changed while enabling auto-merge' }); continue; }
+                  await mergeCleanPullRequest(candidate.number, currentHeadSha);
+                  results.push({ number: candidate.number, action: 'merged-after-clean-race' });
                   continue;
                 }
               }
+              results.push({ number: candidate.number, action: 'auto-merge-enabled' });
             }
-            console.table(results);
-            return results;
+            await core.summary.addHeading('Required QA auto-merge').addRaw(results.length === 0 ? 'No eligible Dependabot pull requests found.' : results.map((result) => `- #${result.number}: ${result.action}${result.reason ? ` — ${result.reason}` : ''}`).join('\n')).write();

--- a/.github/workflows/auto-release.workflow.yml
+++ b/.github/workflows/auto-release.workflow.yml
@@ -101,15 +101,17 @@ jobs:
         run: yarn build
 
       - name: 🧪 Verify package archive and installation
+        env:
+          NPM_CONFIG_USERCONFIG: /dev/null
         run: |
           set -euo pipefail
           package_dir=$(mktemp -d)
+          package_manager=$(node -p "require('./package.json').packageManager")
           yarn pack --filename "$package_dir/package.tar.gz"
           tar -tzf "$package_dir/package.tar.gz" >/dev/null
           cd "$package_dir"
-          yarn init -y
-          touch yarn.lock
-          yarn add -D ./package.tar.gz
+          printf '{"name":"fastypest-install-smoke","version":"1.0.0","private":true,"packageManager":"%s"}\n' "$package_manager" > package.json
+          corepack yarn add -D ./package.tar.gz
 
       - name: 🔎 Check npm publication state
         id: npm


### PR DESCRIPTION
## What
- isolate the npm package-install smoke test from `actions/setup-node` publisher authentication while preserving the existing trusted-publisher workflow path and OIDC contract
- harden `required QA` processing around exact-head approvals, clean PRs, branch-update races, repositories with pending requirements, and workflow-file changes
- use the protected owner `PAT_FINE` only for event-emitting merge/branch transitions so downstream workflows remain eligible to run
- refuse to request the sensitive Workflows permission; behind PRs that modify workflows are reported for trusted manual refresh and fresh approval

## Why
The real `v3.0.42` auto-release reached the consumer smoke test and failed because the setup-node npm config referenced `${NODE_AUTH_TOKEN}` even though trusted publishing intentionally uses OIDC without a long-lived npm token. The shared QA auto-merge implementation also had two runtime failure modes observed in the rollout: GraphQL auto-merge rejects an already `clean` PR, and GitHub rejects automatic refresh of workflow-changing branches without Workflows permission.

## Security
- exact current-head maintainer approval is required and revalidated before mutation
- bot approvals and stale approvals remain invalid
- merges are bound to the exact head SHA and use squash
- no `pull_request_target`, force push, Workflows permission, admin bypass flag, or npm token fallback is added
- `.github/workflows/auto-release.workflow.yml` remains the npm trusted-publisher identity and keeps `id-token: write`
- dry-run remains non-mutating

## Validation
- final diff is limited to the release workflow, required-QA workflow, and task spec
- the package smoke change is step-local; npm publication still uses the setup-node publisher configuration
- pull-request CI is the final authority and must be green before merge

## Impact
This implementation PR does not merge Dependabot PRs, create a release, publish npm, or deploy anything. The affected live workflows are intentionally not re-run from this PR because doing so could perform those privileged transitions.

## Rollback
Revert this pull request. No migration is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated package release verification to use the project’s configured package manager and isolated test settings.
  * Improved Dependabot pull request auto-merge reliability by validating approvals, branch status, labels, and merge readiness.
  * Added safeguards to prevent unintended merges and handle race conditions or permission issues safely.

* **Chores**
  * Added documentation covering automation hardening, acceptance checks, rollback procedures, and delivery status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->